### PR TITLE
Fixing and improving hundreds of mistranslations.

### DIFF
--- a/macOS/zh-Hans/ActivateProxymanIOSGuidelineViewController.strings
+++ b/macOS/zh-Hans/ActivateProxymanIOSGuidelineViewController.strings
@@ -14,7 +14,7 @@
 "ZLg-ek-DeR.title" = "去应用商店...";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy AppStore URL"; ObjectID = "aiQ-Z0-KRb"; */
-"aiQ-Z0-KRb.ibShadowedToolTip" = "复制 AppStore 网址";
+"aiQ-Z0-KRb.ibShadowedToolTip" = "拷贝 AppStore 网址";
 
 /* Class = "NSTextFieldCell"; title = "Support iOS & iPadOS. Require iOS 14+."; ObjectID = "bTD-X7-grf"; */
 "bTD-X7-grf.title" = "支持 iOS 和 iPadOS。需要 iOS 14+。";

--- a/macOS/zh-Hans/AtlantisViewController.strings
+++ b/macOS/zh-Hans/AtlantisViewController.strings
@@ -5,7 +5,7 @@
 "1XJ-cw-FoT.title" = "<key>NSLocalNetworkUsageDescription</key>\n<string>Atlantis 将使用 Bonjour 服务从您的本地网络发现 Proxyman 应用程序。</string>\n<key>NSBonjourServices</key>\n<array>\n <string >_Proxyman._tcp</string>\n</array>";
 
 /* Class = "NSTextFieldCell"; title = "Atlantis.start()"; ObjectID = "5EY-Rj-gkk"; */
-"5EY-Rj-gkk.title" = "亚特兰蒂斯.start()";
+"5EY-Rj-gkk.title" = "Atlantis.start()";
 
 /* Class = "NSButtonCell"; title = " Support iOS Physical Devices and Simulators"; ObjectID = "70u-YQ-QHo"; */
 "70u-YQ-QHo.title" = " 支持 iOS 物理设备和模拟器";
@@ -14,25 +14,25 @@
 "74P-8C-9Fq.title" = "+ 如果您只想连接到您的 Mac 而不是同事的 Mac：";
 
 /* Class = "NSTextFieldCell"; title = "A little and powerful iOS framework for intercepting HTTP/HTTPS Traffic from your app. \nNo more messing around with proxy and certificate config."; ObjectID = "DbA-qH-UCG"; */
-"DbA-qH-UCG.title" = "一个小巧而强大的 iOS 框架，用于从您的应用中拦截 HTTP/HTTPS 流量。 \n不要再搞乱代理和证书配置了。";
+"DbA-qH-UCG.title" = "一个小巧而强大的 iOS 框架，用于从您的应用中窃听 HTTP/HTTPS 流量。 \n不用再搞乱代理和证书配置了。";
 
 /* Class = "NSButtonCell"; title = " Inspect network traffic on Proxyman app"; ObjectID = "DwI-LG-lqG"; */
-"DwI-LG-lqG.title" = " 检查 Proxyman 应用程序上的网络流量";
+"DwI-LG-lqG.title" = " 在 Proxyman 上检视网络流量";
 
 /* Class = "NSTextFieldCell"; title = "🧰 Atlantis - iOS Framework"; ObjectID = "EoS-fV-A7W"; */
-"EoS-fV-A7W.title" = "🧰 亚特兰蒂斯 - iOS 框架";
+"EoS-fV-A7W.title" = "🧰 Atlantis - iOS 框架";
 
 /* Class = "NSTextFieldCell"; title = "https://github.com/ProxymanApp/atlantis"; ObjectID = "ErA-FZ-Eke"; */
 "ErA-FZ-Eke.title" = "https://github.com/ProxymanApp/atlantis";
 
 /* Class = "NSButtonCell"; title = "Bonjour Service Error:"; ObjectID = "Kx3-DJ-4V2"; */
-"Kx3-DJ-4V2.title" = "你好服务错误：";
+"Kx3-DJ-4V2.title" = "Bonjour服务错误：";
 
 /* Class = "NSTextFieldCell"; title = "Install via CocoaPod:"; ObjectID = "LK3-Dm-2PS"; */
 "LK3-Dm-2PS.title" = "通过 CocoaPod 安装：";
 
 /* Class = "NSTextFieldCell"; title = "By default, Atlantis will connect to all Proxyman apps from other Mac on the same Network."; ObjectID = "M21-pX-A3l"; */
-"M21-pX-A3l.title" = "默认情况下，亚特兰蒂斯将连接到同一网络上其他 Mac 上的所有 Proxyman 应用程序。";
+"M21-pX-A3l.title" = "默认情况下，Atlantis 将连接到同一网络中所有其他 Mac 的 Proxyman 应用程序。";
 
 /* Class = "NSButtonCell"; title = " Capture WebSocket from URLSessionWebsocketTask"; ObjectID = "NIt-8E-iJ4"; */
 "NIt-8E-iJ4.title" = " 从 URLSessionWebsocketTask 捕获 WebSocket";
@@ -41,13 +41,13 @@
 "NfB-kK-FXd.title" = "将以下代码添加到 Info.plist (iOS 14+)";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy"; ObjectID = "PkR-iH-H1j"; */
-"PkR-iH-H1j.ibShadowedToolTip" = "复制";
+"PkR-iH-H1j.ibShadowedToolTip" = "拷贝";
 
 /* Class = "NSTextFieldCell"; title = "Atlantis.start(hostName: \"nghias\")"; ObjectID = "VwY-dG-rTd"; */
 "VwY-dG-rTd.title" = "Atlantis.start（主机名：\“装饰\”）";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy"; ObjectID = "Yfe-og-Un2"; */
-"Yfe-og-Un2.ibShadowedToolTip" = "复制";
+"Yfe-og-Un2.ibShadowedToolTip" = "拷贝";
 
 /* Class = "NSBox"; title = "Box"; ObjectID = "Yqs-Cb-G8d"; */
 "Yqs-Cb-G8d.title" = "盒子";
@@ -65,10 +65,10 @@
 "bya-og-kQj.title" = "+ 如果您只有一台 Mac：";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy"; ObjectID = "cye-18-Mv1"; */
-"cye-18-Mv1.ibShadowedToolTip" = "复制";
+"cye-18-Mv1.ibShadowedToolTip" = "拷贝";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy"; ObjectID = "egS-8e-yfa"; */
-"egS-8e-yfa.ibShadowedToolTip" = "复制";
+"egS-8e-yfa.ibShadowedToolTip" = "拷贝";
 
 /* Class = "NSButtonCell"; title = "Only Support macOS 10.14+"; ObjectID = "g0h-DO-kXC"; */
 "g0h-DO-kXC.title" = "仅支持 macOS 10.14+";
@@ -80,22 +80,22 @@
 "i97-oV-dgj.title" = "添加到应用程序(_:didFinishLaunchingWithOptions:)";
 
 /* Class = "NSButtonCell"; title = " Your Atlantis iOS version is out-of-date and not compatible. Please update Atlantis!"; ObjectID = "nRT-uP-e0V"; */
-"nRT-uP-e0V.title" = " 您的 Atlantis iOS 版本已过时且不兼容。请更新亚特兰蒂斯！";
+"nRT-uP-e0V.title" = " 您的 Atlantis iOS 版本已过时且不兼容。请更新 Atlantis ！";
 
 /* Class = "NSTextFieldCell"; title = "pod 'atlantis-proxyman'"; ObjectID = "nkB-fj-i3i"; */
-"nkB-fj-i3i.title" = "pod“亚特兰蒂斯代理”";
+"nkB-fj-i3i.title" = "pod 'atlantis-proxyman'";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy"; ObjectID = "nw5-9I-htw"; */
-"nw5-9I-htw.ibShadowedToolTip" = "复制";
+"nw5-9I-htw.ibShadowedToolTip" = "拷贝";
 
 /* Class = "NSButtonCell"; title = "Github..."; ObjectID = "txQ-HR-Di4"; */
 "txQ-HR-Di4.title" = "GitHub...";
 
 /* Class = "NSButtonCell"; title = "How to Start Atlantis?"; ObjectID = "ycQ-Jd-yLH"; */
-"ycQ-Jd-yLH.title" = "如何开始亚特兰蒂斯？";
+"ycQ-Jd-yLH.title" = "如何启动 Atlantis ？";
 
 /* Class = "NSButtonCell"; title = " Automatically intercept all HTTP/HTTPS Traffic from your iOS app"; ObjectID = "zXg-wd-cNO"; */
 "zXg-wd-cNO.title" = " 自动拦截来自您的 iOS 应用程序的所有 HTTP/HTTPS 流量";
 
 /* Class = "NSTextFieldCell"; title = "Enable Atlantis Service"; ObjectID = "uWV-DL-U4w"; */
-"uWV-DL-U4w.title" = "启用亚特兰蒂斯服务";
+"uWV-DL-U4w.title" = "启用 Atlantis 服务";

--- a/macOS/zh-Hans/Certificates.strings
+++ b/macOS/zh-Hans/Certificates.strings
@@ -284,7 +284,7 @@
 "Uqv-6K-0Ez.title" = "3.2: 添加到 AndroidManifest.xml";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy IP Address"; ObjectID = "V5X-Ik-jEt"; */
-"V5X-Ik-jEt.ibShadowedToolTip" = "复制 IP 地址";
+"V5X-Ik-jEt.ibShadowedToolTip" = "拷贝 IP 地址";
 
 /* Class = "NSTextFieldCell"; title = "Proxyman CA"; ObjectID = "VJb-wr-l1g"; */
 "VJb-wr-l1g.title" = "Proxyman CA";
@@ -416,7 +416,7 @@
 "jno-Mx-64Y.title" = "删除";
 
 /* Class = "NSButtonCell"; title = "Try Atlantis for iOS"; ObjectID = "k41-aG-wU7"; */
-"k41-aG-wU7.title" = "试试 iOS 版亚特兰蒂斯";
+"k41-aG-wU7.title" = "试试 Atlantis for iOS";
 
 /* Class = "NSTextFieldCell"; title = "Make sure you remove these configs from your Production build."; ObjectID = "kNC-HC-635"; */
 "kNC-HC-635.title" = "确保从您的生产版本中移除这些配置。";

--- a/macOS/zh-Hans/CodeGeneratorViewController.strings
+++ b/macOS/zh-Hans/CodeGeneratorViewController.strings
@@ -1,8 +1,8 @@
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Copy to Clipboard"; ObjectID = "30Z-6w-W10"; */
-"30Z-6w-W10.ibShadowedToolTip" = "复制到剪贴板";
+"30Z-6w-W10.ibShadowedToolTip" = "拷贝到剪贴板";
 
 /* Class = "NSMenuItem"; title = "Copy"; ObjectID = "30Z-6w-W10"; */
-"30Z-6w-W10.title" = "复制";
+"30Z-6w-W10.title" = "拷贝";
 
 /* Class = "NSMenuItem"; title = "Swift + Moya"; ObjectID = "FKH-yT-4Uk"; */
 "FKH-yT-4Uk.title" = "斯威夫特+莫亚";
@@ -11,10 +11,10 @@
 "GJQ-An-MDc.title" = "JavaScript + jQuery";
 
 /* Class = "NSMenuItem"; title = "Python + Request"; ObjectID = "HPx-Ay-pen"; */
-"HPx-Ay-pen.title" = "Python + 请求";
+"HPx-Ay-pen.title" = "Python + Request";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Copy to Clipboard"; ObjectID = "LWu-Yc-aqa"; */
-"LWu-Yc-aqa.ibShadowedToolTip" = "复制到剪贴板";
+"LWu-Yc-aqa.ibShadowedToolTip" = "拷贝到剪贴板";
 
 /* Class = "NSMenuItem"; title = "HTTPie"; ObjectID = "MSc-h5-wuV"; */
 "MSc-h5-wuV.title" = "HTTPie";
@@ -23,7 +23,7 @@
 "SbY-FI-5Av.title" = "按钮";
 
 /* Class = "NSMenuItem"; title = "Missing your library?..."; ObjectID = "TSs-CW-bJ7"; */
-"TSs-CW-bJ7.title" = "想念你的图书馆？...";
+"TSs-CW-bJ7.title" = "你用的库不在此处？...";
 
 /* Class = "NSMenuItem"; title = "cURL"; ObjectID = "YVk-sF-Oko"; */
 "YVk-sF-Oko.title" = "cURL";
@@ -32,19 +32,19 @@
 "YeD-JT-LFC.title" = "盒子";
 
 /* Class = "NSMenuItem"; title = "Node + Fetch"; ObjectID = "chl-fm-YTF"; */
-"chl-fm-YTF.title" = "节点+获取";
+"chl-fm-YTF.title" = "Node + Fetch";
 
 /* Class = "NSMenuItem"; title = "HAR"; ObjectID = "dYb-uG-XTa"; */
-"dYb-uG-XTa.title" = "头发";
+"dYb-uG-XTa.title" = "HAR";
 
 /* Class = "NSMenuItem"; title = "Axios"; ObjectID = "fq9-xP-hRQ"; */
 "fq9-xP-hRQ.title" = "Axios";
 
 /* Class = "NSMenuItem"; title = "Go"; ObjectID = "jgF-tK-sdX"; */
-"jgF-tK-sdX.title" = "去";
+"jgF-tK-sdX.title" = "Go";
 
 /* Class = "NSMenuItem"; title = "Postman Collection 2"; ObjectID = "l9i-Sx-Y0U"; */
-"l9i-Sx-Y0U.title" = "邮递员系列 2";
+"l9i-Sx-Y0U.title" = "Postman Collection 2";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Export to File"; ObjectID = "lHt-eV-8sA"; */
 "lHt-eV-8sA.ibShadowedToolTip" = "导出到文件";
@@ -59,13 +59,13 @@
 "sBg-5N-b9t.title" = "Java + HTTP客户端";
 
 /* Class = "NSMenuItem"; title = "Swift + URLSession"; ObjectID = "vxP-NZ-8jX"; */
-"vxP-NZ-8jX.title" = "斯威夫特 + URLSession";
+"vxP-NZ-8jX.title" = "Swift + URLSession";
 
 /* Class = "NSMenuItem"; title = "Objective-C + NSURLSession"; ObjectID = "yti-b4-WeI"; */
-"yti-b4-WeI.title" = "目标-C + NSURLSession";
+"yti-b4-WeI.title" = "Objective-C + NSURLSession";
 
 /* Class = "NSMenuItem"; title = "Node + HTTP"; ObjectID = "zjK-7R-rFI"; */
-"zjK-7R-rFI.title" = "节点 + HTTP";
+"zjK-7R-rFI.title" = "Node + HTTP";
 
 /* Class = "NSMenuItem"; title = "Swift + Alamofire"; ObjectID = "zqd-fj-Rsf"; */
-"zqd-fj-Rsf.title" = "斯威夫特 + 阿拉莫火";
+"zqd-fj-Rsf.title" = "Swift + Alamofire";

--- a/macOS/zh-Hans/Content.strings
+++ b/macOS/zh-Hans/Content.strings
@@ -1,5 +1,5 @@
 /* Class = "NSMenuItem"; title = "Copy"; ObjectID = "0Ec-tm-ZJS"; */
-"0Ec-tm-ZJS.title" = "复制";
+"0Ec-tm-ZJS.title" = "拷贝";
 
 /* Class = "NSTextFieldCell"; title = "No Selection"; ObjectID = "2dL-Y7-QWR"; */
 "2dL-Y7-QWR.title" = "无选择";
@@ -137,7 +137,7 @@
 "wC4-JC-OdQ.headerCell.title" = "类型";
 
 /* Class = "NSTextFieldCell"; title = "Summary"; ObjectID = "wU1-sd-O8r"; */
-"wU1-sd-O8r.title" = "总结";
+"wU1-sd-O8r.title" = "摘要";
 
 /* Class = "NSTabViewItem"; label = "Key Value"; ObjectID = "ww6-R1-qnh"; */
 "ww6-R1-qnh.label" = "关键值";

--- a/macOS/zh-Hans/Diff.strings
+++ b/macOS/zh-Hans/Diff.strings
@@ -164,7 +164,7 @@
 "yQV-wm-J4q.title" = "盒子";
 
 /* Class = "NSTextFieldCell"; title = "2. ⌘Y or Right-Click -> Tools -> Add to Diff Pool"; ObjectID = "yYR-bn-Vqt"; */
-"yYR-bn-Vqt.title" = "2. ⌘Y 或右键单击 -> 工具 -> 添加到差异池";
+"yYR-bn-Vqt.title" = "2. ⌘Y 或右键单击 -> 工具 -> 添加到对比池";
 
 /* Class = "NSTextFieldCell"; title = "1. Select the request/response on the main view"; ObjectID = "ygt-Sk-AxV"; */
 "ygt-Sk-AxV.title" = "1. 在主视图中选择请求/响应";

--- a/macOS/zh-Hans/Filters.strings
+++ b/macOS/zh-Hans/Filters.strings
@@ -62,10 +62,10 @@
 "BIf-fI-giN.title" = "自定义列...";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Any Header Key / Value of the Request"; ObjectID = "BOC-fF-zPl"; */
-"BOC-fF-zPl.ibShadowedToolTip" = "请求的任何标题键/值";
+"BOC-fF-zPl.ibShadowedToolTip" = "任何请求的标头键/值对";
 
 /* Class = "NSMenuItem"; title = "Request Header"; ObjectID = "BOC-fF-zPl"; */
-"BOC-fF-zPl.title" = "请求头";
+"BOC-fF-zPl.title" = "请求标头";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Only show WS/WSS Messages"; ObjectID = "BUV-mo-Fuo"; */
 "BUV-mo-Fuo.ibShadowedToolTip" = "只显示 WS/WSS 消息";
@@ -140,7 +140,7 @@
 "Kzk-G3-tXi.title" = "请求正文";
 
 /* Class = "NSTextFieldCell"; title = "Show: ⌘F    New: ⌘N    Remove:⇧⌘N    Up:⌘↑    Down: ⌘↓    On/Off:⌘B    Hide: ESC"; ObjectID = "Lhj-Uq-WDx"; */
-"Lhj-Uq-WDx.title" = "显示：⌘F 新：⌘N 删除：⇧⌘N 上：⌘↑ 下：⌘↓ 开/关：⌘B 隐藏：ESC";
+"Lhj-Uq-WDx.title" = "显示：⌘F  新增：⌘N  移除：⇧⌘N  上一个：⌘↑  下一个：⌘↓  开/关：⌘B  隐藏：ESC";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Other requests (⌘ click to select multiple types)"; ObjectID = "MBC-Bd-PMb"; */
 "MBC-Bd-PMb.ibShadowedToolTip" = "其他请求（⌘点击选择多种类型）";
@@ -179,7 +179,7 @@
 "TXl-p4-ehr.ibShadowedToolTip" = "响应的任何标题键/值";
 
 /* Class = "NSMenuItem"; title = "Response Header"; ObjectID = "TXl-p4-ehr"; */
-"TXl-p4-ehr.title" = "响应头";
+"TXl-p4-ehr.title" = "响应标头";
 
 /* Class = "NSButtonCell"; title = "3xx"; ObjectID = "U2i-PN-qmi"; */
 "U2i-PN-qmi.title" = "3xx";
@@ -227,7 +227,7 @@
 "dEE-WL-vzl.ibShadowedToolTip" = "请求的完整 URL";
 
 /* Class = "NSMenuItem"; title = "URL"; ObjectID = "dEE-WL-vzl"; */
-"dEE-WL-vzl.title" = "网址";
+"dEE-WL-vzl.title" = "URL";
 
 /* Class = "NSButtonCell"; title = "CSS"; ObjectID = "e0Q-IX-lxg"; */
 "e0Q-IX-lxg.title" = "CSS";

--- a/macOS/zh-Hans/FlowSummaryViewController.strings
+++ b/macOS/zh-Hans/FlowSummaryViewController.strings
@@ -11,4 +11,4 @@
 "mSb-Pr-L9g.headerCell.title" = "名称";
 
 /* Class = "NSMenuItem"; title = "Copy"; ObjectID = "oF2-YY-nho"; */
-"oF2-YY-nho.title" = "复制";
+"oF2-YY-nho.title" = "拷贝";

--- a/macOS/zh-Hans/HeaderTableView.strings
+++ b/macOS/zh-Hans/HeaderTableView.strings
@@ -5,7 +5,7 @@
 "Zd0-vA-oaT.title" = "文本单元格";
 
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "dWF-YL-RKO"; */
-"dWF-YL-RKO.headerCell.title" = "钥匙";
+"dWF-YL-RKO.headerCell.title" = "键";
 
 /* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "wf3-ni-n6E"; */
 "wf3-ni-n6E.headerCell.title" = "值";

--- a/macOS/zh-Hans/HelpMapLocalViewController.strings
+++ b/macOS/zh-Hans/HelpMapLocalViewController.strings
@@ -8,7 +8,7 @@
 "Cxh-Ep-6Fp.title" = "•";
 
 /* Class = "NSButtonCell"; title = "Copy to Clipboard"; ObjectID = "FNd-sP-Bc6"; */
-"FNd-sP-Bc6.title" = "复制到剪贴板";
+"FNd-sP-Bc6.title" = "拷贝到剪贴板";
 
 /* Class = "NSTextFieldCell"; title = "https:\\/\\/my-server\\.com\\/build\\/v1\\/(.*)"; ObjectID = "H1Q-Yv-j27"; */
 "H1Q-Yv-j27.title" = "https:\\/\\/my-server\\.com\\/build\\/v1\\/(.*)";

--- a/macOS/zh-Hans/ImportExportSettingViewController.strings
+++ b/macOS/zh-Hans/ImportExportSettingViewController.strings
@@ -1,2 +1,2 @@
 /* Class = "NSMenuItem"; title = "Import from Charles Proxy Settings"; ObjectID = "3Bu-vx-9gM"; */
-"3Bu-vx-9gM.title" = "从 Charles 代理设置导入";
+"3Bu-vx-9gM.title" = "从 Charles Proxy设置导入";

--- a/macOS/zh-Hans/JSONTreeView.strings
+++ b/macOS/zh-Hans/JSONTreeView.strings
@@ -8,7 +8,7 @@
 "3mm-s7-79e.title" = "了解如何使用带键路径的过滤器...";
 
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "9qQ-Zb-W6P"; */
-"9qQ-Zb-W6P.headerCell.title" = "钥匙";
+"9qQ-Zb-W6P.headerCell.title" = "键";
 
 /* Class = "NSMenuItem"; title = "Key Path"; ObjectID = "Bs5-nU-llz"; */
 "Bs5-nU-llz.title" = "关键路径";

--- a/macOS/zh-Hans/Localizable.strings
+++ b/macOS/zh-Hans/Localizable.strings
@@ -188,7 +188,7 @@
 "Add" = "加";
 
 /* No comment provided by engineer. */
-"Add %d items to Diff Pool…" = "将 %d 个项目添加到差异池...";
+"Add %d items to Diff Pool…" = "将 %d 个项目添加到对比池...";
 
 /* No comment provided by engineer. */
 "Add (⌘⏎)" = "添加 （⌘⏎）";
@@ -203,7 +203,7 @@
 "Add Comment…" = "添加备注...";
 
 /* No comment provided by engineer. */
-"Add to Diff Pool…" = "添加到差异池...";
+"Add to Diff Pool…" = "添加到对比池...";
 
 /* No comment provided by engineer. */
 "Add Wildcard Host" = "添加通配符主机";
@@ -221,13 +221,13 @@
 "All good!" = "都很好！";
 
 /* No comment provided by engineer. */
-"Allow List" = "允许列表";
+"Allow List" = "白名单";
 
 /* No comment provided by engineer. */
-"Allow List Toggle" = "允许列表切换";
+"Allow List Toggle" = "白名单开关";
 
 /* No comment provided by engineer. */
-"Allow List…" = "允许列表...";
+"Allow List…" = "白名单...";
 
 /* No comment provided by engineer. */
 "Android Debug Bridge (adb) not found!" = "未找到 Android Debug Bridge （adb）！";
@@ -254,16 +254,16 @@
 "Are you sure to unlink this device?" = "是否确实要取消关联此设备？";
 
 /* No comment provided by engineer. */
-"as CSV" = "作为 CSV 格式";
+"as CSV" = "为CSV";
 
 /* No comment provided by engineer. */
-"as HAR (HTTP Archive)" = "作为 HAR （HTTP Archive）";
+"as HAR (HTTP Archive)" = "为HAR（HTTP 归档）";
 
 /* No comment provided by engineer. */
-"as Postman" = "作为 Postman";
+"as Postman" = "为Postman 文件";
 
 /* No comment provided by engineer. */
-"as Proxyman Log" = "作为 Proxyman Log";
+"as Proxyman Log" = "为Proxyman 日志";
 
 /* No comment provided by engineer. */
 "Auth" = "认证";
@@ -281,13 +281,13 @@
 "Block & Hide" = "阻止和隐藏";
 
 /* No comment provided by engineer. */
-"Block List" = "阻止列表";
+"Block List" = "黑名单";
 
 /* No comment provided by engineer. */
-"Block List Toggle" = "阻止列表切换";
+"Block List Toggle" = "黑名单开关";
 
 /* No comment provided by engineer. */
-"Block List…" = "阻止列表...";
+"Block List…" = "黑名单...";
 
 /* No comment provided by engineer. */
 "Block Requests" = "阻止请求";
@@ -296,25 +296,25 @@
 "Blocked by Block Tool" = "被阻止工具阻止";
 
 /* No comment provided by engineer. */
-"Blue" = "蓝";
+"Blue" = "蓝色";
 
 /* No comment provided by engineer. */
 "Body" = "Body";
 
 /* No comment provided by engineer. */
-"Body over 5Mb hidden for performance reasons" = "由于性能原因，机身超过 5Mb 隐藏";
+"Body over 5Mb hidden for performance reasons" = "出于性能考量，隐藏超过5Mb 的正文";
 
 /* No comment provided by engineer. */
 "Breakpoint" = "断点";
 
 /* No comment provided by engineer. */
-"Breakpoint Toggle" = "断点切换";
+"Breakpoint Toggle" = "断点开关";
 
 /* No comment provided by engineer. */
 "Breakpoint URL" = "断点网址";
 
 /* No comment provided by engineer. */
-"Breakpoint…" = "断点。。。";
+"Breakpoint…" = "断点...";
 
 /* No comment provided by engineer. */
 "Buy a license" = "购买许可证";
@@ -332,10 +332,10 @@
 "Clear entire session to release all caching memory (⌥+⇧+⌘+⌫)" = "清除整个会话以释放所有缓存内存 （⌥+⇧+⌘+⌫）";
 
 /* No comment provided by engineer. */
-"Click to Add Comment...\n\nHighlight this request by Right-click on the Request -> Highlight" = "单击以添加备注...\n\n通过右键单击请求来突出显示此请求 -> 突出显示";
+"Click to Add Comment...\n\nHighlight this request by Right-click on the Request -> Highlight" = "单击以添加备注...\n\n通过右键单击请求 -> 高亮来突出显示此请求";
 
 /* No comment provided by engineer. */
-"Click to copy the current IP Address" = "单击以复制当前 IP 地址";
+"Click to copy the current IP Address" = "单击以拷贝当前 IP 地址";
 
 /* No comment provided by engineer. */
 "Click to download new update" = "点击下载新的更新";
@@ -350,7 +350,7 @@
 "Client TLS Version" = "客户端 TLS 版本";
 
 /* No comment provided by engineer. */
-"Code" = "法典";
+"Code" = "响应代码";
 
 /* No comment provided by engineer. */
 "Code Generator…" = "代码生成器...";
@@ -362,7 +362,7 @@
 "Comment" = "备注";
 
 /* No comment provided by engineer. */
-"Common Name" = "公用名";
+"Common Name" = "常用名称";
 
 /* No comment provided by engineer. */
 "Completed" = "完成";
@@ -398,49 +398,49 @@
 "Convert .chls -> .har" = "转换 .chls -> .har";
 
 /* No comment provided by engineer. */
-"Cookies" = "饼干";
+"Cookies" = "Cookies";
 
 /* No comment provided by engineer. */
-"Copied" = "复制";
+"Copied" = "已拷贝";
 
 /* No comment provided by engineer. */
-"Copy" = "复制";
+"Copy" = "拷贝";
 
 /* No comment provided by engineer. */
-"Copy %d URLs" = "复制 %d 个网址";
+"Copy %d URLs" = "拷贝 %d 个网址";
 
 /* No comment provided by engineer. */
-"Copy as" = "复制为";
+"Copy as" = "拷贝为";
 
 /* No comment provided by engineer. */
-"Copy Cell Value" = "复制单元格值";
+"Copy Cell Value" = "拷贝单元格值";
 
 /* No comment provided by engineer. */
-"Copy cURL" = "复制 cURL";
+"Copy cURL" = "拷贝 cURL";
 
 /* No comment provided by engineer. */
-"Copy first 500 URLs" = "复制前 500 个 URL";
+"Copy first 500 URLs" = "拷贝前 500 个 URL";
 
 /* No comment provided by engineer. */
-"Copy IP Address and Port" = "复制 IP 地址和端口";
+"Copy IP Address and Port" = "拷贝 IP 地址和端口";
 
 /* No comment provided by engineer. */
-"Copy Key & Value" = "复制密钥和值";
+"Copy Key & Value" = "拷贝键和值";
 
 /* No comment provided by engineer. */
-"Copy Key and Value object" = "复制键和值对象";
+"Copy Key and Value object" = "拷贝键和值对象";
 
 /* No comment provided by engineer. */
-"Copy only IP" = "仅复制 IP";
+"Copy only IP" = "仅拷贝 IP";
 
 /* No comment provided by engineer. */
-"Copy URL" = "复制网址";
+"Copy URL" = "拷贝网址";
 
 /* No comment provided by engineer. */
-"Copy Value" = "复制值";
+"Copy Value" = "拷贝值";
 
 /* No comment provided by engineer. */
-"Copy value of selected row (JSON Node if it's an Array or Object, or plain value for other types)" = "所选行的复制值（JSON 节点，如果它是数组或对象，或者是其他类型的纯值）";
+"Copy value of selected row (JSON Node if it's an Array or Object, or plain value for other types)" = "拷贝所选行的值（如果它是数组或对象，将拷贝为JSON Node。其它类型将被拷贝成纯值。）";
 
 /* No comment provided by engineer. */
 "Core start failed" = "核心启动失败";
@@ -584,7 +584,7 @@
 "Create Block Rule for this domain (include sub-directories) by dropping all connections" = "通过删除所有连接为此域（包括子目录）创建阻止规则";
 
 /* No comment provided by engineer. */
-"Create Block Rules: Allow to Block / Hide certain domains during debugging session." = "创建阻止规则：允许在调试会话期间阻止/隐藏某些域。";
+"Create Block Rules: Allow to Block / Hide certain domains during debugging session." = "创建阻止规则：允许在调试会话期间阻止/隐藏某些域名。";
 
 /* No comment provided by engineer. */
 "Create Breakpoint Rule for this domain (include sub-directories) to modify the Request and Response on the fly" = "为此域（包括子目录）创建断点规则以动态修改请求和响应";
@@ -605,7 +605,7 @@
 "Create Script Rule for selected flows" = "为所选流创建脚本规则";
 
 /* No comment provided by engineer. */
-"Current Listening Proxy IP:Port" = "当前侦听代理 IP：端口";
+"Current Listening Proxy IP:Port" = "当前监听代理 IP：端口";
 
 /* No comment provided by engineer. */
 "Data and Certificates are deleted!" = "数据和证书被删除！";
@@ -671,7 +671,7 @@
 "DNS(s)" = "DNS(s)";
 
 /* No comment provided by engineer. */
-"Domains" = "域";
+"Domains" = "域名";
 
 /* No comment provided by engineer. */
 "Done (⌘⏎)" = "完成 （⌘⏎）";
@@ -680,10 +680,10 @@
 "Download Old Build" = "下载旧版本";
 
 /* No comment provided by engineer. */
-"Dropped Connection due to Block List" = "由于阻止列表导致连接断开";
+"Dropped Connection due to Block List" = "由于黑名单导致连接断开";
 
 /* No comment provided by engineer. */
-"Duration" = "耗时";
+"Duration" = "持续时间";
 
 /* No comment provided by engineer. */
 "Duration (exact)" = "持续时间（精确）";
@@ -704,7 +704,7 @@
 "Edit and Repeat…" = "编辑并重复...";
 
 /* No comment provided by engineer. */
-"Edited" = "编辑";
+"Edited" = "编辑过";
 
 /* No comment provided by engineer. */
 "Empty Body" = "空体";
@@ -719,10 +719,10 @@
 "Empty PAC URL." = "空的 PAC 网址。";
 
 /* No comment provided by engineer. */
-"Enable all domains from \"%@\"" = "启用所有域 \"%@\"";
+"Enable all domains from \"%@\"" = "对所有来自 \"%@\" 的域名启用";
 
 /* No comment provided by engineer. */
-"Enable only this domain" = "仅启用此域";
+"Enable only this domain" = "只对此域名启用";
 
 /* No comment provided by engineer. */
 "Enable SSL Proxying" = "启用 SSL 代理";
@@ -758,7 +758,7 @@
 "Expand Status Code Filters" = "展开状态代码筛选器";
 
 /* No comment provided by engineer. */
-"Export" = "出口";
+"Export" = "导出";
 
 /* No comment provided by engineer. */
 "Export all data of Request and Response to Proxyman File (Recommended)" = "将请求和响应的所有数据导出到 Proxyman 文件（推荐）";
@@ -803,7 +803,7 @@
 "External Proxy" = "外部代理";
 
 /* No comment provided by engineer. */
-"External Proxy Toggle" = "外部代理切换";
+"External Proxy Toggle" = "外部代理开关";
 
 /* No comment provided by engineer. */
 "Favorites" = "收藏夹";
@@ -872,7 +872,7 @@
 "Gray" = "灰色";
 
 /* No comment provided by engineer. */
-"Green" = "绿";
+"Green" = "绿色";
 
 /* No comment provided by engineer. */
 "Haven't supported: Convert from %@ to Proxyman Type. Please open the Ticket on Github for feature requests." = "不支持：从 %@ 转换为代理类型。请在 Github 上打开票证以请求功能。";
@@ -1031,7 +1031,7 @@
 "Invalid patch string: %@" = "修补程序字符串无效：%@";
 
 /* No comment provided by engineer. */
-"Invalid Protobuf Data" = "无效的原型数据";
+"Invalid Protobuf Data" = "无效的Protobuf数据";
 
 /* No comment provided by engineer. */
 "Invalid Proxy Server" = "无效的代理服务器";
@@ -1058,10 +1058,10 @@
 "iOS Settings app > Wi-Fi > Select current Wi-Fi > Configure Proxy > Manual" = "iOS设置应用程序>Wi-Fi>选择当前的Wi-Fi>配置代理>手册";
 
 /* No comment provided by engineer. */
-"Issued By" = "颁发者";
+"Issued By" = "签发者";
 
 /* No comment provided by engineer. */
-"Issued To" = "颁发给";
+"Issued To" = "签发给";
 
 /* No comment provided by engineer. */
 "It could be SSL Certificate Pinning, or try installing CA Certificate on iOS Simulators again" = "它可以是 SSL 证书固定，或者再次尝试在 iOS 模拟器上安装 CA 证书";
@@ -1103,19 +1103,19 @@
 "License Manager" = "许可证管理器";
 
 /* No comment provided by engineer. */
-"Listen on %@:%d" = "在 %@：%d 上侦听";
+"Listen on %@:%d" = "在 %@：%d 上监听";
 
 /* No comment provided by engineer. */
-"Listening on %@" = "收听 %@";
+"Listening on %@" = "监听 %@";
 
 /* No comment provided by engineer. */
-"Listening on port %@" = "侦听端口 %@";
+"Listening on port %@" = "监听端口 %@";
 
 /* No comment provided by engineer. */
 "Locality" = "地区";
 
 /* No comment provided by engineer. */
-"macOS Proxy Overridden" = "macOS 代理被覆盖";
+"macOS Proxy Overridden" = "重载macOS 代理";
 
 /* No comment provided by engineer. */
 "Make sure to turn OFF all VPNs from your Macbook and Android devices." = "确保关闭 Macbook 和 Android 设备上的所有 VPN。";
@@ -1136,7 +1136,7 @@
 "Manager Header Columns…" = "管理器标题列...";
 
 /* No comment provided by engineer. */
-"Manual…" = "手动。。。";
+"Manual…" = "使用手册...";
 
 /* No comment provided by engineer. */
 "Map as HTTP Body" = "映射为 HTTP 正文";
@@ -1154,7 +1154,7 @@
 "Map Local for \(items.count) Requests…" = "映射 \\（items.count） 请求的本地...";
 
 /* No comment provided by engineer. */
-"Map Local Toggle" = "本地映射切换";
+"Map Local Toggle" = "本地映射开关";
 
 /* No comment provided by engineer. */
 "Map Local…" = "本地映射...";
@@ -1163,7 +1163,7 @@
 "Map Remote" = "远程映射";
 
 /* No comment provided by engineer. */
-"Map Remote Toggle" = "远程映射切换";
+"Map Remote Toggle" = "远程映射开关";
 
 /* No comment provided by engineer. */
 "Map Remote…" = "远程映射...";
@@ -1304,7 +1304,7 @@
 "Only accept sharedState as a Dictionary!" = "只接受 sharedState 作为字典！";
 
 /* No comment provided by engineer. */
-"Only copy IP Address" = "仅复制 IP 地址";
+"Only copy IP Address" = "仅拷贝 IP 地址";
 
 /* No comment provided by engineer. */
 "Only support HTTP Response" = "仅支持 HTTP 响应";
@@ -1349,7 +1349,7 @@
 "Pause recording" = "暂停录制";
 
 /* No comment provided by engineer. */
-"Pin" = "固定";
+"Pin" = "固定到文件夹";
 
 /* No comment provided by engineer. */
 "Pin to Favorites" = "固定到收藏夹";
@@ -1427,7 +1427,7 @@
 "Processing..." = "加工。。。";
 
 /* No comment provided by engineer. */
-"Protobuf…" = "原虫...";
+"Protobuf…" = "Protobuf...";
 
 /* No comment provided by engineer. */
 "Proxy" = "代理";
@@ -1439,7 +1439,7 @@
 "Proxy Helper tool is better performance than using networksetup CLI" = "代理帮助程序工具比使用网络设置 CLI 的性能更好";
 
 /* No comment provided by engineer. */
-"Proxy Overridden Toggle" = "代理覆盖切换";
+"Proxy Overridden Toggle" = "代理覆盖开关";
 
 /* No comment provided by engineer. */
 "Proxy server: Require Authentication" = "代理服务器：需要身份验证";
@@ -1508,13 +1508,13 @@
 "Raw Request & Response" = "原始请求和响应";
 
 /* No comment provided by engineer. */
-"Re-send your request to see new content" = "重新发送查看新内容的请求";
+"Re-send your request to see new content" = "重新发送请求以查看新的内容";
 
 /* No comment provided by engineer. */
 "Record Traffic" = "记录流量";
 
 /* No comment provided by engineer. */
-"Red" = "红";
+"Red" = "红色";
 
 /* No comment provided by engineer. */
 "Redirect" = "重定向";
@@ -1565,7 +1565,7 @@
 "Request" = "Request";
 
 /* No comment provided by engineer. */
-"Request & Response panels are hidden!" = "请求和响应面板是隐藏的！";
+"Request & Response panels are hidden!" = "请求和响应面板被隐藏了！";
 
 /* No comment provided by engineer. */
 "Request aborted by Breakpoint" = "请求因断点而中止";
@@ -1589,7 +1589,7 @@
 "Request Body..." = "请求正文...";
 
 /* No comment provided by engineer. */
-"Request Cookie" = "请求饼干";
+"Request Cookie" = "请求Cookie";
 
 /* No comment provided by engineer. */
 "Request End Time" = "请求结束时间";
@@ -1655,7 +1655,7 @@
 "Response Code" = "响应代码";
 
 /* No comment provided by engineer. */
-"Response Cookie" = "响应饼干";
+"Response Cookie" = "响应Cookie";
 
 /* No comment provided by engineer. */
 "Response End Time" = "响应结束时间";
@@ -1691,7 +1691,7 @@
 "Reverse Proxy" = "反向代理";
 
 /* No comment provided by engineer. */
-"Reverse Proxy Toggle" = "反向代理切换";
+"Reverse Proxy Toggle" = "反向代理开关";
 
 /* No comment provided by engineer. */
 "Right" = "右";
@@ -1733,10 +1733,10 @@
 "Scripting" = "脚本";
 
 /* No comment provided by engineer. */
-"Scripting Toggle" = "脚本切换";
+"Scripting Toggle" = "脚本开关";
 
 /* No comment provided by engineer. */
-"Scripting…" = "脚本。。。";
+"Scripting…" = "脚本...";
 
 /* No comment provided by engineer. */
 "Secure Web Proxy (HTTPS)" = "Secure Web Proxy （HTTPS）";
@@ -1778,7 +1778,7 @@
 "Show in Finder…" = "在 Finder 中显示...";
 
 /* No comment provided by engineer. */
-"Show Proxyman" = "节目 Proxyman";
+"Show Proxyman" = "显示 Proxyman";
 
 /* No comment provided by engineer. */
 "Simulate Network Conditions with various Preset Profiles" = "使用各种预设配置文件模拟网络条件";
@@ -1844,7 +1844,7 @@
 "Strikethrough" = "删除线";
 
 /* No comment provided by engineer. */
-"Summary" = "总结";
+"Summary" = "摘要";
 
 /* No comment provided by engineer. */
 "Support * and ?. Should not include Path or Query" = "支持 * 和 ？。不应包含路径或查询";
@@ -1898,37 +1898,37 @@
 "to version" = "到版本";
 
 /* No comment provided by engineer. */
-"Toggle Dock to Bottom Window ⌃⌘]" = "切换停靠到底部窗口 ⌃⌘]";
+"Toggle Dock to Bottom Window ⌃⌘]" = "将 Dock 切换到窗口底部 ⌃⌘]";
 
 /* No comment provided by engineer. */
-"Toggle Dock to Right Window ⌃⌘\\" = "将 Dock 切换到右窗口 ⌃⌘\\\\";
+"Toggle Dock to Right Window ⌃⌘\\" = "将 Dock 切换到窗口右侧 ⌃⌘\\\\";
 
 /* No comment provided by engineer. */
-"Toggle Left Sidebar ⌃⌘[" = "切换左侧边栏 ⌃⌘[";
+"Toggle Left Sidebar ⌃⌘[" = "开关左侧边栏 ⌃⌘[";
 
 /* No comment provided by engineer. */
-"Toggle Proxy Overridden" = "切换代理覆盖";
+"Toggle Proxy Overridden" = "开关代理重载";
 
 /* No comment provided by engineer. */
-"Toggle Recording Traffic" = "切换记录流量";
+"Toggle Recording Traffic" = "开关流量记录";
 
 /* No comment provided by engineer. */
-"Toggle Request Panel" = "切换请求面板";
+"Toggle Request Panel" = "开关请求面板";
 
 /* No comment provided by engineer. */
-"Toggle Response Panel" = "切换响应面板";
+"Toggle Response Panel" = "开关响应面板";
 
 /* No comment provided by engineer. */
-"Toggle the Filter Bar on the current tab (⌘F)" = "切换当前选项卡上的筛选器栏 （⌘F）";
+"Toggle the Filter Bar on the current tab (⌘F)" = "开关当前选项卡上的筛选器栏 （⌘F）";
 
 /* No comment provided by engineer. */
-"Toggle Tools" = "切换工具";
+"Toggle Tools" = "开关工具";
 
 /* No comment provided by engineer. */
-"Too many requests for Repeat Tool" = "对重复工具的请求过多";
+"Too many requests for Repeat Tool" = "重复工具的请求过多";
 
 /* No comment provided by engineer. */
-"Toogle Tools" = "太格尔工具";
+"Toogle Tools" = "开关工具";
 
 /* No comment provided by engineer. */
 "Tool Name" = "工具名称";
@@ -1976,7 +1976,7 @@
 "Unknown" = "未知";
 
 /* No comment provided by engineer. */
-"Unknown Common Name" = "未知公用名";
+"Unknown Common Name" = "未知的常用名称";
 
 /* No comment provided by engineer. */
 "Unknown Javascript Error" = "未知的 Javascript 错误";
@@ -2084,10 +2084,10 @@
 "Your current HTTP/HTTPS Proxy is overridden by Proxy Helper Tool." = "您当前的 HTTP/HTTPS 代理被 代理帮助程序工具 重载。";
 
 /* No comment provided by engineer. */
-"Your HTTP/HTTPS Proxy is overridden by Proxyman (ip=%@ port=%d) (Toggle by: ⌥⌘O)" = "您的 HTTP/HTTPS Proxy 被 Proxyman 覆盖 （ip=%@ port=%d） （切换方式： ⌥⌘O）";
+"Your HTTP/HTTPS Proxy is overridden by Proxyman (ip=%@ port=%d) (Toggle by: ⌥⌘O)" = "您的 HTTP/HTTPS Proxy 被 Proxyman 覆盖 （ip=%@ port=%d） （开关方式： ⌥⌘O）";
 
 /* No comment provided by engineer. */
-"Your HTTP/HTTPS Proxy is overridden by Proxyman (port=%d) (Toggle by: ⌥⌘O)" = "您的 HTTP/HTTPS Proxy 被 Proxyman 覆盖 （port=%d） （切换方式： ⌥⌘O）";
+"Your HTTP/HTTPS Proxy is overridden by Proxyman (port=%d) (Toggle by: ⌥⌘O)" = "您的 HTTP/HTTPS Proxy 被 Proxyman 覆盖 （port=%d） （开关方式： ⌥⌘O）";
 
 /* No comment provided by engineer. */
 "Your license is expired!" = "您的许可证已过期！";
@@ -2183,10 +2183,10 @@
 "Add --proxy flag into %@ command" = "在 %@ 命令中添加 --proxy 标志";
 
 /* No comment provided by engineer. */
-"Copy HTTPie" = "复制 HTTPie";
+"Copy HTTPie" = "拷贝 HTTPie";
 
 /* No comment provided by engineer. */
-"Copy selected requests with %@ format" = "使用 %@ 格式复制选定的请求";
+"Copy selected requests with %@ format" = "使用 %@ 格式拷贝选定的请求";
 
 /* No comment provided by engineer. */
 "It allows Proxyman capture %@ traffic." = "此标志允许 Proxyman 捕获 %@ 流量。";

--- a/macOS/zh-Hans/Main.strings
+++ b/macOS/zh-Hans/Main.strings
@@ -17,7 +17,7 @@
 "1Xt-HY-uBw.title" = "Proxyman";
 
 /* Class = "NSMenu"; title = "Find"; ObjectID = "1b7-l0-nxx"; */
-"1b7-l0-nxx.title" = "寻找";
+"1b7-l0-nxx.title" = "查找";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "All Proxyman Certificate will be removed"; ObjectID = "1cY-IH-L90"; */
 "1cY-IH-L90.ibShadowedToolTip" = "所有 Proxyman 证书将被删除";
@@ -38,7 +38,7 @@
 "2eA-6u-s1g.title" = "停用缓存";
 
 /* Class = "NSButtonCell"; title = "Allow List"; ObjectID = "3JW-nX-CMn"; */
-"3JW-nX-CMn.title" = "允许列表";
+"3JW-nX-CMn.title" = "白名单";
 
 /* Class = "NSButtonCell"; title = "No Caching"; ObjectID = "3ns-bq-OcJ"; */
 "3ns-bq-OcJ.title" = "停用缓存";
@@ -47,7 +47,7 @@
 "460-rg-fFI.title" = "在 iOS 上安装证书";
 
 /* Class = "NSMenuItem"; title = "Find"; ObjectID = "4EN-yA-p0u"; */
-"4EN-yA-p0u.title" = "寻找";
+"4EN-yA-p0u.title" = "查找";
 
 /* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "4J7-dP-txa"; */
 "4J7-dP-txa.title" = "进入全屏";
@@ -71,7 +71,7 @@
 "4rb-xr-f83.title" = "脚本";
 
 /* Class = "NSMenuItem"; title = "Quit Proxyman"; ObjectID = "4sb-4s-VLi"; */
-"4sb-4s-VLi.title" = "退出代理";
+"4sb-4s-VLi.title" = "退出Proxyman";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Scripting is enabled (⌥⌘I)"; ObjectID = "5L7-nW-b98"; */
 "5L7-nW-b98.ibShadowedToolTip" = "脚本已启用 (⌥⌘I)";
@@ -167,10 +167,10 @@
 "Asg-75-GFE.title" = "反向代理...";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Copy selected request as cURL/HTTPie format"; ObjectID = "AwM-lX-ZaA"; */
-"AwM-lX-ZaA.ibShadowedToolTip" = "将所选流复制为 cURL 请求";
+"AwM-lX-ZaA.ibShadowedToolTip" = "将所选请求拷贝为 cURL 请求";
 
 /* Class = "NSMenuItem"; title = "Copy as cURL"; ObjectID = "AwM-lX-ZaA"; */
-"AwM-lX-ZaA.title" = "复制为 cURL";
+"AwM-lX-ZaA.title" = "拷贝为 cURL";
 
 /* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
 "BOF-NM-1cW.title" = "偏好设置…";
@@ -206,7 +206,7 @@
 "C9u-Xq-jpW.title" = "请求和响应";
 
 /* Class = "NSMenuItem"; title = "Technical Documents…"; ObjectID = "Cjg-r7-MG3"; */
-"Cjg-r7-MG3.title" = "技术文件...";
+"Cjg-r7-MG3.title" = "技术文档...";
 
 /* Class = "NSWindow"; title = "Proxyman"; ObjectID = "Ckk-yw-fiv"; */
 "Ckk-yw-fiv.title" = "Proxyman";
@@ -218,7 +218,7 @@
 "CzI-85-4Ih.title" = "添加自定义证书...";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
-"DVo-aG-piG.title" = "关";
+"DVo-aG-piG.title" = "关闭";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Create new folder in Source Panel (Left Panel)"; ObjectID = "DWA-p4-NCT"; */
 "DWA-p4-NCT.ibShadowedToolTip" = "在源面板（左面板）中创建新文件夹";
@@ -269,7 +269,7 @@
 "G7r-Ai-wOV.title" = "变更日志…";
 
 /* Class = "NSMenuItem"; title = "as HAR (HTTP Archive)"; ObjectID = "GCw-x0-RRD"; */
-"GCw-x0-RRD.title" = "作为 HAR（HTTP 存档）";
+"GCw-x0-RRD.title" = "为HAR（HTTP 归档）";
 
 /* Class = "NSMenu"; title = "Diff"; ObjectID = "GVQ-jl-aJy"; */
 "GVQ-jl-aJy.title" = "对比";
@@ -302,7 +302,7 @@
 "IAo-SY-fd9.title" = "打开…";
 
 /* Class = "NSMenu"; title = "Highlight"; ObjectID = "IBf-9y-v8u"; */
-"IBf-9y-v8u.title" = "强调";
+"IBf-9y-v8u.title" = "高亮";
 
 /* Class = "NSMenuItem"; title = "*.local requests do not appear on Proxyman?…"; ObjectID = "ICa-uJ-cwx"; */
 "ICa-uJ-cwx.title" = "*.local 请求没有出现在 Proxyman 上？...";
@@ -335,13 +335,13 @@
 "Kd2-mp-pUS.title" = "显示所有";
 
 /* Class = "NSMenuItem"; title = "Highlight"; ObjectID = "Kgh-wC-mpr"; */
-"Kgh-wC-mpr.title" = "强调";
+"Kgh-wC-mpr.title" = "高亮";
 
 /* Class = "NSMenuItem"; title = "Breakpoint"; ObjectID = "Kim-fe-7qg"; */
 "Kim-fe-7qg.title" = "断点";
 
 /* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
-"LE2-aR-0XJ.title" = "把一切带到前面";
+"LE2-aR-0XJ.title" = "将所有窗口带到最前";
 
 /* Class = "NSMenuItem"; title = "Install Certificate on Android"; ObjectID = "LPx-O2-n19"; */
 "LPx-O2-n19.title" = "在 Android 上安装证书";
@@ -368,10 +368,10 @@
 "NMo-om-nkz.title" = "服务";
 
 /* Class = "NSMenuItem"; title = "Proxyman for iOS…"; ObjectID = "NVp-Bk-pm9"; */
-"NVp-Bk-pm9.title" = "iOS的代理...";
+"NVp-Bk-pm9.title" = "iOS 的 Proxyman...";
 
 /* Class = "NSMenuItem"; title = "From Proxyman"; ObjectID = "Ncd-Sv-Y7F"; */
-"Ncd-Sv-Y7F.title" = "来自 Proxyman";
+"Ncd-Sv-Y7F.title" = "从 Proxyman";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "NeH-TW-9PE"; */
 "NeH-TW-9PE.title" = "文本单元格";
@@ -380,7 +380,7 @@
 "NjY-vl-9ro.title" = "网络状况...";
 
 /* Class = "NSMenuItem"; title = "Get SSL Errors from HTTPS Request and Response?…"; ObjectID = "Npz-di-X2z"; */
-"Npz-di-X2z.title" = "从 HTTPS 请求和响应中获取 SSL 错误？...";
+"Npz-di-X2z.title" = "从 HTTPS 请求和响应中遇到了 SSL 错误？...";
 
 /* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "最小化";
@@ -416,13 +416,13 @@
 "PwA-fQ-eaG.title" = "覆盖 macOS 代理";
 
 /* Class = "NSButtonCell"; title = "Proxy Overridden"; ObjectID = "QVb-xA-A0h"; */
-"QVb-xA-A0h.title" = "代理被覆盖";
+"QVb-xA-A0h.title" = "代理已重载";
 
 /* Class = "NSMenu"; title = "Troubleshooting"; ObjectID = "QWa-6G-Xq7"; */
 "QWa-6G-Xq7.title" = "故障排除";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Drop connection for all matched URLs on blocklist"; ObjectID = "Qvq-a9-0aG"; */
-"Qvq-a9-0aG.ibShadowedToolTip" = "删除阻止列表中所有匹配 URL 的连接";
+"Qvq-a9-0aG.ibShadowedToolTip" = "删除黑名单中所有匹配 URL 的连接";
 
 /* Class = "NSMenuItem"; title = "Block List…"; ObjectID = "Qvq-a9-0aG"; */
 "Qvq-a9-0aG.title" = "黑名单…";
@@ -581,10 +581,10 @@
 "bqg-mb-EG7.ibShadowedToolTip" = "如果出现问题，如何检索数据的教程！";
 
 /* Class = "NSMenuItem"; title = "Lost Data?…"; ObjectID = "bqg-mb-EG7"; */
-"bqg-mb-EG7.title" = "丢失数据？...";
+"bqg-mb-EG7.title" = "丢失了数据？...";
 
 /* Class = "NSMenuItem"; title = "From Charles Proxy"; ObjectID = "bqz-Ef-vED"; */
-"bqz-Ef-vED.title" = "从Charles代理";
+"bqz-Ef-vED.title" = "从Charles Proxy";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Use Proxyman with Docker"; ObjectID = "bte-hE-8Pw"; */
 "bte-hE-8Pw.ibShadowedToolTip" = "将 Proxyman 与 Docker 一起使用";
@@ -593,10 +593,10 @@
 "bte-hE-8Pw.title" = "Docker…";
 
 /* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "buJ-ug-pKt"; */
-"buJ-ug-pKt.title" = "使用选择进行查找";
+"buJ-ug-pKt.title" = "使用过滤器进行查找";
 
 /* Class = "NSMenuItem"; title = "Convert"; ObjectID = "cUE-Z0-jBK"; */
-"cUE-Z0-jBK.title" = "兑换";
+"cUE-Z0-jBK.title" = "转换";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Map Local is enabled (⌥⌘L)"; ObjectID = "cX1-mf-48B"; */
 "cX1-mf-48B.ibShadowedToolTip" = "本地映射已启用 (⌥⌘L)";
@@ -605,7 +605,7 @@
 "dBR-4N-MkK.ibShadowedToolTip" = "定义 Protobuf 设置以正确解析";
 
 /* Class = "NSMenuItem"; title = "Protobuf…"; ObjectID = "dBR-4N-MkK"; */
-"dBR-4N-MkK.title" = "原型…";
+"dBR-4N-MkK.title" = "Protobuf…";
 
 /* Class = "NSMenuItem"; title = "File"; ObjectID = "dMs-cI-mzQ"; */
 "dMs-cI-mzQ.title" = "文件";
@@ -704,7 +704,7 @@
 "hz9-B4-Xy5.title" = "服务";
 
 /* Class = "NSMenu"; title = "Convert"; ObjectID = "i8J-io-caN"; */
-"i8J-io-caN.title" = "兑换";
+"i8J-io-caN.title" = "转换";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Manage the Previewer Tabs on Request or Response Panel"; ObjectID = "iee-fo-ccT"; */
 "iee-fo-ccT.ibShadowedToolTip" = "管理请求或响应面板上的预览器选项卡";
@@ -806,7 +806,7 @@
 "ozy-tH-5wN.title" = "将所选项目添加到对比列表...";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Allow List is applied to record exclusively matched URLs. Other URLs are ignored  (⌥⌘A)"; ObjectID = "p1m-xS-O9V"; */
-"p1m-xS-O9V.ibShadowedToolTip" = "允许列表用于记录完全匹配的 URL。其他 URL 被忽略 (⌥⌘A)";
+"p1m-xS-O9V.ibShadowedToolTip" = "白名单用于记录完全匹配的 URL。其他 URL 被忽略 (⌥⌘A)";
 
 /* Class = "NSMenuItem"; title = "Github…"; ObjectID = "p3m-pz-uha"; */
 "p3m-pz-uha.title" = "GitHub…";
@@ -818,7 +818,7 @@
 "pph-dX-usQ.title" = "来自 Proxyman";
 
 /* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "q09-fT-Sye"; */
-"q09-fT-Sye.title" = "找下一个";
+"q09-fT-Sye.title" = "查找下一个";
 
 /* Class = "NSMenu"; title = "Certificate"; ObjectID = "q4m-y1-nYE"; */
 "q4m-y1-nYE.title" = "证书";
@@ -905,7 +905,7 @@
 "wpr-3q-Mcd.title" = "帮助";
 
 /* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
-"x3v-GG-iWU.title" = "复制";
+"x3v-GG-iWU.title" = "拷贝";
 
 /* Class = "NSButtonCell"; title = "Dock to Side Windows"; ObjectID = "xI1-27-z4r"; */
 "xI1-27-z4r.title" = "停靠到侧窗";
@@ -923,13 +923,13 @@
 "xti-kr-tkZ.title" = "应用程序...";
 
 /* Class = "NSMenuItem"; title = "Proxyman for macOS…"; ObjectID = "xuK-i2-5fM"; */
-"xuK-i2-5fM.title" = "macOS 的代理…";
+"xuK-i2-5fM.title" = "macOS 的 Proxyman…";
 
 /* Class = "NSMenuItem"; title = "Breakpoints..."; ObjectID = "yBE-G1-kKG"; */
 "yBE-G1-kKG.title" = "断点...";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Block List is applied to block all matched URLs  (⌥⌘X)"; ObjectID = "yHp-Wk-jHo"; */
-"yHp-Wk-jHo.ibShadowedToolTip" = "阻止列表用于阻止所有匹配的 URL (⌥⌘X)";
+"yHp-Wk-jHo.ibShadowedToolTip" = "黑名单用于阻止所有匹配的 URL (⌥⌘X)";
 
 /* Class = "NSButtonCell"; title = "Skip exporting large body data (>= 5Mb) of Requests / Responses"; ObjectID = "yIg-2W-rqg"; */
 "yIg-2W-rqg.title" = "跳过导出请求/响应的大型正文数据 (>= 5Mb)";
@@ -959,7 +959,7 @@
 "zRf-ev-leU.ibShadowedToolTip" = "仅捕获匹配的 URL。忽略其余的";
 
 /* Class = "NSMenuItem"; title = "Allow List…"; ObjectID = "zRf-ev-leU"; */
-"zRf-ev-leU.title" = "允许列表...";
+"zRf-ev-leU.title" = "白名单...";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Add new domains or apps into Source Panel (Left Panel)"; ObjectID = "zXo-eI-h7d"; */
 "zXo-eI-h7d.ibShadowedToolTip" = "将新域或应用程序添加到源面板（左面板）";
@@ -974,7 +974,7 @@
 "zYz-aO-geY.title" = "根证书为 P12...";
 
 /* Class = "NSMenuItem"; title = "Proxyman does not work with my VPN?…"; ObjectID = "zfm-Nx-lph"; */
-"zfm-Nx-lph.title" = "Proxyman 不适用于我的 VPN？...";
+"zfm-Nx-lph.title" = "Proxyman 不与我的 VPN 兼容？...";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Toggle Enable/Disable the Breakpoint Tool"; ObjectID = "5bG-V7-Rho"; */
 "5bG-V7-Rho.ibShadowedToolTip" = "切换启用/禁用断点工具";
@@ -983,7 +983,7 @@
 "5bG-V7-Rho.title" = "断点";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Toggle Enable/Disable the Block List Tool"; ObjectID = "7gm-fb-2xP"; */
-"7gm-fb-2xP.ibShadowedToolTip" = "切换启用/禁用阻止列表工具";
+"7gm-fb-2xP.ibShadowedToolTip" = "切换启用/禁用黑名单工具";
 
 /* Class = "NSMenuItem"; title = "Block List"; ObjectID = "7gm-fb-2xP"; */
 "7gm-fb-2xP.title" = "黑名单";
@@ -998,10 +998,10 @@
 "Jbb-Ov-C7d.title" = "本地映射";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Toggle Enable/Disable the Allow List Tool"; ObjectID = "Mrd-VT-G6e"; */
-"Mrd-VT-G6e.ibShadowedToolTip" = "切换启用/禁用允许列表工具";
+"Mrd-VT-G6e.ibShadowedToolTip" = "切换启用/禁用白名单工具";
 
 /* Class = "NSMenuItem"; title = "Allow List"; ObjectID = "Mrd-VT-G6e"; */
-"Mrd-VT-G6e.title" = "允许列表";
+"Mrd-VT-G6e.title" = "白名单";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Toggle Enable/Disable the Map Remtote Tool"; ObjectID = "Uei-Ey-Z6a"; */
 "Uei-Ey-Z6a.ibShadowedToolTip" = "切换启用/禁用远程映射工具";

--- a/macOS/zh-Hans/MatchingRuleView.strings
+++ b/macOS/zh-Hans/MatchingRuleView.strings
@@ -1,5 +1,5 @@
 /* Class = "NSMenuItem"; title = "OPTIONS"; ObjectID = "0r1-Xi-hIE"; */
-"0r1-Xi-hIE.title" = "选项";
+"0r1-Xi-hIE.title" = "OPTIONS";
 
 /* Class = "NSTextFieldCell"; title = "Full-Matching Regex"; ObjectID = "1l3-Xs-tGg"; */
 "1l3-Xs-tGg.title" = "完全匹配的正则表达式";
@@ -11,13 +11,13 @@
 "2ay-oz-ZRe.title" = "高级设置";
 
 /* Class = "NSMenuItem"; title = "DELETE"; ObjectID = "3be-oa-kOQ"; */
-"3be-oa-kOQ.title" = "删除";
+"3be-oa-kOQ.title" = "DELETE";
 
 /* Class = "NSMenuItem"; title = "HEAD"; ObjectID = "6Rs-ss-bnI"; */
-"6Rs-ss-bnI.title" = "头";
+"6Rs-ss-bnI.title" = "HEAD";
 
 /* Class = "NSMenuItem"; title = "GET"; ObjectID = "6uW-oj-aMf"; */
-"6uW-oj-aMf.title" = "得到";
+"6uW-oj-aMf.title" = "GET";
 
 /* Class = "NSTextFieldCell"; title = "Simple wildcard * and ? are supported"; ObjectID = "UnC-Gv-LIU"; */
 "UnC-Gv-LIU.title" = "简单的通配符 * 和 ?支持";
@@ -26,7 +26,7 @@
 "YlL-v0-VaZ.title" = "高级设置";
 
 /* Class = "NSMenuItem"; title = "POST"; ObjectID = "Ysk-hj-HK6"; */
-"Ysk-hj-HK6.title" = "邮政";
+"Ysk-hj-HK6.title" = "POST";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Use simple Wildcard (* and ?)"; ObjectID = "aLr-49-U0F"; */
 "aLr-49-U0F.ibShadowedToolTip" = "使用简单的通配符（* 和？）";
@@ -35,7 +35,7 @@
 "aLr-49-U0F.title" = "使用通配符";
 
 /* Class = "NSMenuItem"; title = "PATCH"; ObjectID = "aMn-qb-GlQ"; */
-"aMn-qb-GlQ.title" = "修补";
+"aMn-qb-GlQ.title" = "PATCH";
 
 /* Class = "NSMenuItem"; title = "ANY"; ObjectID = "e6b-ss-qIB"; */
 "e6b-ss-qIB.title" = "任何";
@@ -59,10 +59,10 @@
 "tCp-2f-uaq.title" = "包含此 URL 的所有子路径";
 
 /* Class = "NSMenuItem"; title = "TRACE"; ObjectID = "tcx-XF-CqG"; */
-"tcx-XF-CqG.title" = "痕迹";
+"tcx-XF-CqG.title" = "TRACE";
 
 /* Class = "NSButtonCell"; title = "Syntax List"; ObjectID = "uxN-hg-ZVl"; */
 "uxN-hg-ZVl.title" = "语法列表";
 
 /* Class = "NSMenuItem"; title = "PUT"; ObjectID = "voR-V0-TSk"; */
-"voR-V0-TSk.title" = "放";
+"voR-V0-TSk.title" = "PUT";

--- a/macOS/zh-Hans/Preferences.strings
+++ b/macOS/zh-Hans/Preferences.strings
@@ -191,7 +191,7 @@
 "IKr-ow-7xJ.title" = "UI 和语法高亮主题";
 
 /* Class = "NSButtonCell"; title = "Lost Key?"; ObjectID = "IM9-xB-06w"; */
-"IM9-xB-06w.title" = "钥匙丢了？";
+"IM9-xB-06w.title" = "密钥丢了？";
 
 /* Class = "NSMenuItem"; title = "15 seconds"; ObjectID = "ISQ-zy-ocW"; */
 "ISQ-zy-ocW.title" = "15 秒";

--- a/macOS/zh-Hans/PrivateMessageViewController.strings
+++ b/macOS/zh-Hans/PrivateMessageViewController.strings
@@ -1,5 +1,5 @@
 /* Class = "NSTextFieldCell"; title = "It's better to leave feedback, feature requests or bug reports at Proxyman's Github Page"; ObjectID = "18I-ir-n9W"; */
-"18I-ir-n9W.title" = "最好在 Proxyman 的 Github 页面留下反馈、功能请求或错误报告";
+"18I-ir-n9W.title" = "如果能在 Proxyman 的 Github 页面留下反馈、功能请求或错误报告就更好了";
 
 /* Class = "NSTextFieldCell"; placeholderString = "abc@email.com"; ObjectID = "Nwx-CR-Qon"; */
 "Nwx-CR-Qon.placeholderString" = "abc@email.com";
@@ -8,13 +8,13 @@
 "Q6f-uB-yeH.title" = "如果是错误报告，请包括 Proxyman 内部版本号和 macOS 版本";
 
 /* Class = "NSButtonCell"; title = "Open Github Issues"; ObjectID = "aWu-fJ-bJT"; */
-"aWu-fJ-bJT.title" = "打开 Github 问题";
+"aWu-fJ-bJT.title" = "打开 Github Issues";
 
 /* Class = "NSButtonCell"; title = "Send Private Message"; ObjectID = "kJR-5R-bRN"; */
 "kJR-5R-bRN.title" = "发送私信";
 
 /* Class = "NSTextFieldCell"; title = "If you don't want it public, you can send us a private message here"; ObjectID = "oun-uE-gCr"; */
-"oun-uE-gCr.title" = "如果您不想公开，可以在这里给我们发私信";
+"oun-uE-gCr.title" = "如果您不想让这些信息公开，可以在这里给我们发送私信";
 
 /* Class = "NSTextFieldCell"; title = "Follow us on Twitter to get the latest updates"; ObjectID = "uCG-Tb-dsE"; */
 "uCG-Tb-dsE.title" = "在 Twitter 上关注我们以获取最新更新";
@@ -23,10 +23,10 @@
 "uPI-FA-yGV.title" = "发送成功！";
 
 /* Class = "NSTextFieldCell"; title = "Empty Message! Please say Hello!"; ObjectID = "uek-Bu-iRh"; */
-"uek-Bu-iRh.title" = "空消息！请打个招呼！";
+"uek-Bu-iRh.title" = "消息是空的！打个招呼吧！";
 
 /* Class = "NSTextFieldCell"; title = "Your email that we will reply to (Optional)"; ObjectID = "uk2-re-q73"; */
-"uk2-re-q73.title" = "我们将回复您的电子邮件（可选）";
+"uk2-re-q73.title" = "用于接收我们回复的电子邮件（并非必填）";
 
 /* Class = "NSButtonCell"; title = "Twitter"; ObjectID = "yEc-jT-fnl"; */
 "yEc-jT-fnl.title" = "推特";

--- a/macOS/zh-Hans/StatusBarView.strings
+++ b/macOS/zh-Hans/StatusBarView.strings
@@ -14,4 +14,4 @@
 "orN-ge-iKf.title" = " 1";
 
 /* Class = "NSTextFieldCell"; title = "Copied"; ObjectID = "xFL-uj-CsJ"; */
-"xFL-uj-CsJ.title" = "已复制";
+"xFL-uj-CsJ.title" = "已拷贝";

--- a/macOS/zh-Hans/Tools.strings
+++ b/macOS/zh-Hans/Tools.strings
@@ -1,5 +1,5 @@
 /* Class = "NSTextFieldCell"; title = "Protobuf"; ObjectID = "0Ff-RD-OZI"; */
-"0Ff-RD-OZI.title" = "原型缓冲区";
+"0Ff-RD-OZI.title" = "Protobuf 缓冲区";
 
 /* Class = "NSTableColumn"; headerCell.title = "Enabled"; ObjectID = "0Si-T3-xUq"; */
 "0Si-T3-xUq.headerCell.title" = "启用";
@@ -131,7 +131,7 @@
 "Bke-zb-QOr.title" = "盒子";
 
 /* Class = "NSWindow"; title = "Block List"; ObjectID = "Btl-Af-HZO"; */
-"Btl-Af-HZO.title" = "阻止列表";
+"Btl-Af-HZO.title" = "黑名单";
 
 /* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "C4o-ut-1Q3"; */
 "C4o-ut-1Q3.headerCell.title" = "名称";
@@ -206,7 +206,7 @@
 "Hux-u9-Hob.title" = "盒子";
 
 /* Class = "NSWindow"; title = "Map Local"; ObjectID = "HvE-iu-dZA"; */
-"HvE-iu-dZA.title" = "本地";
+"HvE-iu-dZA.title" = "本地映射";
 
 /* Class = "NSTextFieldCell"; title = "Matching Rule:"; ObjectID = "IgZ-Eo-5Xg"; */
 "IgZ-Eo-5Xg.title" = "匹配规则：";
@@ -233,7 +233,7 @@
 "KpL-qD-frB.title" = "如果 Proxyman 上没有显示 localhost 请求，请在 /etc/hosts 文件中设置域别名";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Couldn't find this MessageType in all Protobuf Schema Files. Make sure you include package name"; ObjectID = "Kpb-fD-pcJ"; */
-"Kpb-fD-pcJ.ibShadowedToolTip" = "在所有 Protobuf Schema 文件中都找不到这个 MessageType。确保包含包名";
+"Kpb-fD-pcJ.ibShadowedToolTip" = "在所有 Protobuf Schema 文件中都找不到这个 MessageType。确保你包含了包名";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "LBt-h0-TJp"; */
 "LBt-h0-TJp.title" = "文本单元格";
@@ -248,7 +248,7 @@
 "M61-5L-p5n.title" = "复制";
 
 /* Class = "NSButtonCell"; title = "Protobuf Schema..."; ObjectID = "MBG-sg-M7m"; */
-"MBG-sg-M7m.title" = "Protobuf 架构...";
+"MBG-sg-M7m.title" = "Protobuf Schema...";
 
 /* Class = "NSTextFieldCell"; title = "Protobuf File Descriptor List"; ObjectID = "MPT-OC-LCw"; */
 "MPT-OC-LCw.title" = "Protobuf 文件描述符列表";
@@ -269,7 +269,7 @@
 "O19-c6-aPb.title" = "导入设置";
 
 /* Class = "NSTableColumn"; headerCell.title = "Block Action"; ObjectID = "O8z-LW-TbD"; */
-"O8z-LW-TbD.headerCell.title" = "阻止动作";
+"O8z-LW-TbD.headerCell.title" = "阻止操作";
 
 /* Class = "NSButtonCell"; title = "Done"; ObjectID = "OIK-d8-3EG"; */
 "OIK-d8-3EG.title" = "完成";
@@ -287,7 +287,7 @@
 "Ol3-S1-uzs.title" = "文本单元格";
 
 /* Class = "NSViewController"; title = "Allow List"; ObjectID = "OqY-Ed-ONf"; */
-"OqY-Ed-ONf.title" = "允许列表";
+"OqY-Ed-ONf.title" = "白名单";
 
 /* Class = "NSButtonCell"; title = "Request"; ObjectID = "PSt-De-Jao"; */
 "PSt-De-Jao.title" = "请求";
@@ -305,7 +305,7 @@
 "QPs-zw-YiG.placeholderString" = "443";
 
 /* Class = "NSButtonCell"; title = "Enable Block List Tool"; ObjectID = "QbD-2K-tTV"; */
-"QbD-2K-tTV.title" = "启用阻止列表工具";
+"QbD-2K-tTV.title" = "启用黑名单工具";
 
 /* Class = "NSTextFieldCell"; placeholderString = "https"; ObjectID = "QnD-qF-9SL"; */
 "QnD-qF-9SL.placeholderString" = "https";
@@ -317,7 +317,7 @@
 "Qwb-4B-kSS.title" = "Protobuf 规则";
 
 /* Class = "NSButtonCell"; title = "Always bypass external proxies for localhost"; ObjectID = "ROX-0z-YD2"; */
-"ROX-0z-YD2.title" = "总是绕过本地主机的外部代理";
+"ROX-0z-YD2.title" = "始终为本地主机绕过外部代理";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "RS0-lD-3OF"; */
 "RS0-lD-3OF.title" = "文本单元格";
@@ -362,7 +362,7 @@
 "Vat-v6-QgF.title" = "删除";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Couldn't find this MessageType in all Protobuf Schema Files. Make sure you include package name"; ObjectID = "Ve6-xV-Ub5"; */
-"Ve6-xV-Ub5.ibShadowedToolTip" = "在所有 Protobuf Schema 文件中都找不到这个 MessageType。确保包含包名";
+"Ve6-xV-Ub5.ibShadowedToolTip" = "在所有 Protobuf Schema 文件中都找不到这个 MessageType。确保你包含了包名";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "ViK-WY-Vbx"; */
 "ViK-WY-Vbx.title" = "文本单元格";
@@ -398,7 +398,7 @@
 "WxO-KP-A8t.title" = "导入设置";
 
 /* Class = "NSTextFieldCell"; title = "Define Rules for blocking or hiding particular domains"; ObjectID = "Xyc-Fs-3nf"; */
-"Xyc-Fs-3nf.title" = "定义阻止或隐藏特定域的规则";
+"Xyc-Fs-3nf.title" = "设置规则以阻止或隐藏特定域名";
 
 /* Class = "NSTextFieldCell"; placeholderString = "api.proxyman.io"; ObjectID = "Y7V-9h-Izy"; */
 "Y7V-9h-Izy.placeholderString" = "api.proxyman.io";
@@ -596,7 +596,7 @@
 "lOA-Tr-nm3.title" = "取消";
 
 /* Class = "NSButtonCell"; title = "Enable Allow List Tool"; ObjectID = "lWY-UN-3Di"; */
-"lWY-UN-3Di.title" = "启用允许列表工具";
+"lWY-UN-3Di.title" = "启用白名单工具";
 
 /* Class = "NSTextFieldCell"; title = "Path:"; ObjectID = "lXO-Pq-YX1"; */
 "lXO-Pq-YX1.title" = "路径：";
@@ -614,7 +614,7 @@
 "o2f-BN-OQR.title" = "删除";
 
 /* Class = "NSWindow"; title = "Allow List"; ObjectID = "oRL-hu-zB2"; */
-"oRL-hu-zB2.title" = "允许列表";
+"oRL-hu-zB2.title" = "白名单";
 
 /* Class = "NSButtonCell"; title = "Done"; ObjectID = "oje-TA-GPl"; */
 "oje-TA-GPl.title" = "完成";
@@ -626,7 +626,7 @@
 "orx-y9-b2o.title" = "文本单元格";
 
 /* Class = "NSTextFieldCell"; placeholderString = "id=123"; ObjectID = "oyH-3m-Ptp"; */
-"oyH-3m-Ptp.placeholderString" = "身份证=123";
+"oyH-3m-Ptp.placeholderString" = "id=123";
 
 /* Class = "NSMenuItem"; title = "Export Settings..."; ObjectID = "pCZ-Ap-SjV"; */
 "pCZ-Ap-SjV.title" = "导出设置...";
@@ -665,10 +665,10 @@
 "rLD-D7-Pu3.title" = "来自 Proxyman...";
 
 /* Class = "NSTextFieldCell"; title = "Support Wildcard (* and ?). Separate by Comma."; ObjectID = "rQz-iV-rmI"; */
-"rQz-iV-rmI.title" = "支持通配符（* 和？）。用逗号分隔。";
+"rQz-iV-rmI.title" = "支持通配符（* 和?）。用逗号分隔。";
 
 /* Class = "NSWindow"; title = "Protobuf Schema List"; ObjectID = "rng-I1-ygy"; */
-"rng-I1-ygy.title" = "Protobuf 模式列表";
+"rng-I1-ygy.title" = "Protobuf Schema 列表";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Block all matched requests, but displays them on the app"; ObjectID = "s6a-uq-wFJ"; */
 "s6a-uq-wFJ.ibShadowedToolTip" = "阻止所有匹配的请求，但在应用程序上显示它们";


### PR DESCRIPTION
I unified the translations of the following terms(which are translated differently under different circumstances while meaning the same, and of course caused confusion):
"Block List","Allow List","Find","Diff","Toggle","Highlight","Listen", etc.

I fixed a handful of mistranslations which are far from the originally meaning in English.

I corrected unnecessary translations like "Swift""Alamofire""Objective-C".

I also made formats clean and tidy and coordinated.For example,  translations of colors like "蓝色"(Blue) and "红"(Red) were not formatted in the same way. So I made sure they do so by, for example, changing "红" to "红色".

What's more is that I fixed many incorrect translations which usually happen because the same English word can have multiple meanings.For example,"Key" in the term"Key/Value"  doesn't mean what you use to unlock the door.

There are also changes in tones and  word orders to make it easy to understand.

--------
Proxyman has been available in Chinese since not long before, however the localization is not as satisfying as its amazing design and powerful functionalities.
So, I spent 2 days fixing hundreds of mistranslations and finally let Proxyman's Chinese localization make sense  -- at least in 85% of the app's texts.
I believe this version of localization can truly make non-English-background Chinese users understand 85+% of Proxyman. The 15% remaining  is because I didn't have time to go through all interfaces of Proxyman and I might have made mistakes in what I've done. 
Hopefully this helps. ^_^


