### PR TITLE
fix: improving and unify translations

### DIFF
--- a/macOS/zh-Hans/BreakpointListController.strings
+++ b/macOS/zh-Hans/BreakpointListController.strings
@@ -56,7 +56,7 @@
 "WDx-58-Aps.title" = "导入设置";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; Space: Enable/Disable Rules;"; ObjectID = "WSF-w6-PGd"; */
-"WSF-w6-PGd.title" = "⌘N：新； ⌘⏎：编辑； ⌘⌫：删除； ⌘D：重复；空格：启用/禁用规则；";
+"WSF-w6-PGd.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：复制；空格：启用/禁用规则；";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "fVv-OK-fnS"; */
 "fVv-OK-fnS.title" = "文本单元格";
@@ -95,7 +95,7 @@
 "rpg-qs-XVX.title" = "点击 \"+\" 或 ⌘N 添加新条目";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "ukb-uO-fDz"; */
-"ukb-uO-fDz.title" = "新的...";
+"ukb-uO-fDz.title" = "新建...";
 
 /* Class = "NSMenuItem"; title = "From Charles Proxy..."; ObjectID = "ukm-M2-jKQ"; */
 "ukm-M2-jKQ.title" = "从Charles代理...";

--- a/macOS/zh-Hans/CodeGeneratorViewController.strings
+++ b/macOS/zh-Hans/CodeGeneratorViewController.strings
@@ -53,7 +53,7 @@
 "lHt-eV-8sA.title" = "导出...";
 
 /* Class = "NSMenuItem"; title = "Open with"; ObjectID = "rnF-P9-f0g"; */
-"rnF-P9-f0g.title" = "打开用";
+"rnF-P9-f0g.title" = "打开方式";
 
 /* Class = "NSMenuItem"; title = "Java + HTTPClient"; ObjectID = "sBg-5N-b9t"; */
 "sBg-5N-b9t.title" = "Java + HTTP客户端";

--- a/macOS/zh-Hans/Content.strings
+++ b/macOS/zh-Hans/Content.strings
@@ -32,13 +32,13 @@
 "F8h-zy-Yb1.title" = "文本单元格";
 
 /* Class = "NSMenuItem"; title = "Format with"; ObjectID = "HWM-ws-3XD"; */
-"HWM-ws-3XD.title" = "格式为";
+"HWM-ws-3XD.title" = "格式化为";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Try to format JSON Prettier if possible"; ObjectID = "Jp4-l3-uXg"; */
-"Jp4-l3-uXg.ibShadowedToolTip" = "如果可能，尝试格式化 JSON Prettier";
+"Jp4-l3-uXg.ibShadowedToolTip" = "尝试使用 JSON Prettier 进行格式化";
 
 /* Class = "NSMenuItem"; title = "JSON Prettier"; ObjectID = "Jp4-l3-uXg"; */
-"Jp4-l3-uXg.title" = "JSON 更漂亮";
+"Jp4-l3-uXg.title" = "JSON Prettier";
 
 /* Class = "NSBox"; title = "Box"; ObjectID = "KRI-eZ-xJU"; */
 "KRI-eZ-xJU.title" = "盒子";
@@ -86,7 +86,7 @@
 "Y0J-c2-vMC.label" = "JSON";
 
 /* Class = "NSTextFieldCell"; title = "Malformed multipart/form-data"; ObjectID = "ZDJ-B7-Xee"; */
-"ZDJ-B7-Xee.title" = "畸形 multipart/form-data";
+"ZDJ-B7-Xee.title" = "格式错误的 multipart/form-data";
 
 /* Class = "NSTabViewItem"; label = "Base64"; ObjectID = "c0J-1R-aVI"; */
 "c0J-1R-aVI.label" = "Base64";

--- a/macOS/zh-Hans/Diff.strings
+++ b/macOS/zh-Hans/Diff.strings
@@ -20,7 +20,7 @@
 "8BS-lV-5rL.ibShadowedToolTip" = "所有 JSON 键都按字母顺序排序。如果更改了 JSON 键顺序，则更容易看到对比";
 
 /* Class = "NSMenuItem"; title = "Sort JSON Key"; ObjectID = "8BS-lV-5rL"; */
-"8BS-lV-5rL.title" = "排序 JSON 密钥";
+"8BS-lV-5rL.title" = "排序 JSON 键";
 
 /* Class = "NSTextFieldCell"; title = "Please upgrade your macOS to use this feature (macOS 11.2 or later)."; ObjectID = "8Ul-SW-AQu"; */
 "8Ul-SW-AQu.title" = "请升级您的 macOS 以使用此功能（macOS 11.2 或更高版本）。";
@@ -80,7 +80,7 @@
 "Uwu-CL-nAi.title" = "红色";
 
 /* Class = "NSMenuItem"; title = "Side By Side"; ObjectID = "VgV-en-by3"; */
-"VgV-en-by3.title" = "并排";
+"VgV-en-by3.title" = "并排显示";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "Xwz-Md-J1n"; */
 "Xwz-Md-J1n.title" = "文本单元格";
@@ -155,7 +155,7 @@
 "vMf-zi-skT.headerCell.title" = "对";
 
 /* Class = "NSMenuItem"; title = "Unified"; ObjectID = "xw8-PW-fyB"; */
-"xw8-PW-fyB.title" = "Unified";
+"xw8-PW-fyB.title" = "合并显示";
 
 /* Class = "NSMenuItem"; title = "Blue"; ObjectID = "y5q-RY-LfK"; */
 "y5q-RY-LfK.title" = "蓝色";

--- a/macOS/zh-Hans/Localizable.strings
+++ b/macOS/zh-Hans/Localizable.strings
@@ -5,7 +5,7 @@
 "  Proxyman CA is trusted!" = "Proxyman CA 已经信任！";
 
 /* No comment provided by engineer. */
-" Active" = "积极";
+" Active" = "活跃";
 
 /* No comment provided by engineer. */
 " Could not find '%@' Message Type" = "找不到“%@”消息类型";
@@ -209,7 +209,7 @@
 "Add Wildcard Host" = "添加通配符主机";
 
 /* No comment provided by engineer. */
-"Add…" = "加。。。";
+"Add…" = "添加...";
 
 /* No comment provided by engineer. */
 "All" = "全部";
@@ -251,19 +251,19 @@
 "Are you sure to reset all Proxyman Certificates?" = "您确定要重置所有 Proxyman 证书吗？";
 
 /* No comment provided by engineer. */
-"Are you sure to unlink this device?" = "是否确实要取消关联此设备？";
+"Are you sure to unlink this device?" = "您确定要取消关联此设备吗？";
 
 /* No comment provided by engineer. */
 "as CSV" = "为CSV";
 
 /* No comment provided by engineer. */
-"as HAR (HTTP Archive)" = "为HAR（HTTP 归档）";
+"as HAR (HTTP Archive)" = "为 HAR（HTTP 归档）";
 
 /* No comment provided by engineer. */
-"as Postman" = "为Postman 文件";
+"as Postman" = "为 Postman 文件";
 
 /* No comment provided by engineer. */
-"as Proxyman Log" = "为Proxyman 日志";
+"as Proxyman Log" = "为 Proxyman 日志";
 
 /* No comment provided by engineer. */
 "Auth" = "认证";
@@ -302,7 +302,7 @@
 "Body" = "正文";
 
 /* No comment provided by engineer. */
-"Body over 5Mb hidden for performance reasons" = "出于性能考量，隐藏超过5Mb 的正文";
+"Body over 5Mb hidden for performance reasons" = "出于性能考量，隐藏超过 5Mb 的正文";
 
 /* No comment provided by engineer. */
 "Breakpoint" = "断点";
@@ -1421,7 +1421,7 @@
 "Private Key not found!" = "未找到私钥！";
 
 /* No comment provided by engineer. */
-"Processing..." = "加工。。。";
+"Processing..." = "处理中...";
 
 /* No comment provided by engineer. */
 "Protobuf…" = "Protobuf...";
@@ -1445,13 +1445,13 @@
 "Proxyman Core Error. Please contact us at support@proxyman.io" = "代理核心错误。请通过 support@proxyman.io 联系我们";
 
 /* No comment provided by engineer. */
-"Proxyman could not detect your device." = "代理管理员无法检测到您的设备。";
+"Proxyman could not detect your device." = "Proxyman 无法检测到您的设备。";
 
 /* No comment provided by engineer. */
 "Proxyman could not execute the script with AppleScript. Please grant the permission in System Preference -> Security -> Privacy Tab -> Automation -> Check ON in Proxyman app" = "Proxyman 无法使用 AppleScript 执行脚本。请在系统首选项 - >安全 - >隐私选项卡 - >自动化 - > Proxyman应用程序中的检查中授予权限";
 
 /* No comment provided by engineer. */
-"Proxyman couldn't open this %@ file" = "代理管理员无法打开此%@文件";
+"Proxyman couldn't open this %@ file" = "Proxyman 无法打开此%@文件";
 
 /* prompt shown when user is required to authorize to read the license key */
 "Proxyman is trying to override Proxy config in System Preferences." = "Proxyman正在尝试覆盖“系统偏好设置”中的代理配置。";
@@ -1460,7 +1460,7 @@
 "Proxyman is using the Default Proxyman Root Certificate" = "代理程序正在使用默认代理程序根证书";
 
 /* No comment provided by engineer. */
-"Proxyman is using your Custom Root Certificate" = "代理管理员正在使用您的自定义根证书";
+"Proxyman is using your Custom Root Certificate" = "Proxyman 正在使用您的自定义根证书";
 
 /* No comment provided by engineer. */
 "Proxyman License detected!" = "检测到代理许可证！";
@@ -1823,7 +1823,7 @@
 "Start recording" = "开始录制";
 
 /* No comment provided by engineer. */
-"Starting…" = "开始。。。";
+"Starting…" = "开始...";
 
 /* No comment provided by engineer. */
 "State" = "州";
@@ -2033,10 +2033,10 @@
 "What's new: Remember and Restore to your previous Proxy setting.\n\nGraceful Revert the Proxy if the app is crashed unexpectedly." = "更新内容： 记住并还原到以前的代理设置。\\n\\n如果应用意外崩溃，请恢复代理。";
 
 /* No comment provided by engineer. */
-"Wi-Fi" = "无线网络";
+"Wi-Fi" = "Wi-Fi";
 
 /* No comment provided by engineer. */
-"Wi-Fi 802.11ac" = "无线网络 802.11ac";
+"Wi-Fi 802.11ac" = "Wi-Fi 802.11ac";
 
 /* No comment provided by engineer. */
 "Yellow" = "黄色";

--- a/macOS/zh-Hans/MainBodyPopupButton.strings
+++ b/macOS/zh-Hans/MainBodyPopupButton.strings
@@ -1,8 +1,8 @@
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Try to format JSON Prettier if possible"; ObjectID = "14z-ZK-nTj"; */
-"14z-ZK-nTj.ibShadowedToolTip" = "如果可能，尝试格式化 JSON Prettier";
+"14z-ZK-nTj.ibShadowedToolTip" = "尝试使用 JSON Prettier 进行格式化";
 
 /* Class = "NSMenuItem"; title = "JSON Prettier"; ObjectID = "14z-ZK-nTj"; */
-"14z-ZK-nTj.title" = "JSON 更漂亮";
+"14z-ZK-nTj.title" = "JSON Prettier";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Hex Viewer"; ObjectID = "5BA-bf-GUh"; */
 "5BA-bf-GUh.ibShadowedToolTip" = "十六进制查看器";
@@ -11,7 +11,7 @@
 "5BA-bf-GUh.title" = "十六进制";
 
 /* Class = "NSMenuItem"; title = "Open with"; ObjectID = "9Eu-GW-mB9"; */
-"9Eu-GW-mB9.title" = "打开用";
+"9Eu-GW-mB9.title" = "打开方式";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "\bAutomatically render the Body Previewer (Prettier + Syntax Highlighter)"; ObjectID = "Cyj-74-AnN"; */
 "Cyj-74-AnN.ibShadowedToolTip" = "\b自动渲染 Body Previewer (Prettier + Syntax Highlighter)";
@@ -29,7 +29,7 @@
 "JtX-KM-Uu4.title" = "树视图";
 
 /* Class = "NSMenuItem"; title = "Format with"; ObjectID = "KHU-NI-42K"; */
-"KHU-NI-42K.title" = "格式为";
+"KHU-NI-42K.title" = "格式化为";
 
 /* Class = "NSMenu"; title = "Export"; ObjectID = "SKA-MB-wFH"; */
 "SKA-MB-wFH.title" = "导出";
@@ -38,4 +38,4 @@
 "kKI-m1-n9h.title" = "导出";
 
 /* Class = "NSMenu"; title = "Format with"; ObjectID = "qpj-JX-HEg"; */
-"qpj-JX-HEg.title" = "格式为";
+"qpj-JX-HEg.title" = "格式化为";

--- a/macOS/zh-Hans/MapLocalViewController.strings
+++ b/macOS/zh-Hans/MapLocalViewController.strings
@@ -5,7 +5,7 @@
 "0Y5-A7-VCY.title" = "新建文件夹";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "1Xp-lb-ED7"; */
-"1Xp-lb-ED7.title" = "新的...";
+"1Xp-lb-ED7.title" = "新建...";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Rename the folder"; ObjectID = "49N-U2-jCF"; */
 "49N-U2-jCF.ibShadowedToolTip" = "重命名文件夹";
@@ -74,7 +74,7 @@
 "btk-7i-PcM.title" = "/用户/";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; Space: Enable/Disable Rules;"; ObjectID = "cyA-JP-HlV"; */
-"cyA-JP-HlV.title" = "⌘N：新； ⌘⏎：编辑； ⌘⌫：删除； ⌘D：重复；空格：启用/禁用规则；";
+"cyA-JP-HlV.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：复制；空格：启用/禁用规则；";
 
 /* Class = "NSTextFieldCell"; title = "Map local files or directories as a response for matched requests."; ObjectID = "dEh-4S-1s8"; */
 "dEh-4S-1s8.title" = "映射本地文件或目录作为匹配请求的响应。";

--- a/macOS/zh-Hans/NetworkThrottlingEditController.strings
+++ b/macOS/zh-Hans/NetworkThrottlingEditController.strings
@@ -29,7 +29,7 @@
 "HUe-N8-4Co.title" = "0%";
 
 /* Class = "NSMenuItem"; title = "Wi-Fi"; ObjectID = "JlB-mq-mWy"; */
-"JlB-mq-mWy.title" = "无线上网";
+"JlB-mq-mWy.title" = "Wi-Fi";
 
 /* Class = "NSTextFieldCell"; title = "Download"; ObjectID = "LYH-eN-zlI"; */
 "LYH-eN-zlI.title" = "下载";

--- a/macOS/zh-Hans/NetworkThrottlingViewController.strings
+++ b/macOS/zh-Hans/NetworkThrottlingViewController.strings
@@ -62,7 +62,7 @@
 "UVH-eC-5ha.title" = "一次只能激活 1 个规则";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "V9E-km-YjS"; */
-"V9E-km-YjS.title" = "新的...";
+"V9E-km-YjS.title" = "新建...";
 
 /* Class = "NSMenuItem"; title = "Import Settings"; ObjectID = "VfX-5a-Nkz"; */
 "VfX-5a-Nkz.title" = "导入设置";
@@ -104,4 +104,4 @@
 "yB4-eu-flT.headerCell.title" = "状态";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; ⌘T: Enable/Disable Rules;"; ObjectID = "z9y-BT-pBJ"; */
-"z9y-BT-pBJ.title" = "⌘N：新； ⌘⏎：编辑； ⌘⌫：删除； ⌘D：重复； ⌘T：启用/禁用规则；";
+"z9y-BT-pBJ.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：重复；⌘T：启用/禁用规则；";

--- a/macOS/zh-Hans/ReverseProxyController.strings
+++ b/macOS/zh-Hans/ReverseProxyController.strings
@@ -41,7 +41,7 @@
 "PUd-93-fuq.title" = "文本单元格";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; Space: Enable/Disable Rules;"; ObjectID = "TAb-9X-opy"; */
-"TAb-9X-opy.title" = "⌘N：新； ⌘⏎：编辑； ⌘⌫：删除；空格：启用/禁用规则；";
+"TAb-9X-opy.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；空格：启用/禁用规则；";
 
 /* Class = "NSTableColumn"; headerCell.title = "Remote Host"; ObjectID = "TXc-e9-L8R"; */
 "TXc-e9-L8R.headerCell.title" = "远程主机";
@@ -86,7 +86,7 @@
 "m6w-Jo-aqZ.title" = "启用规则";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "oWR-9H-aa1"; */
-"oWR-9H-aa1.title" = "新的...";
+"oWR-9H-aa1.title" = "新建...";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "u6U-wB-iX5"; */
 "u6U-wB-iX5.title" = "文本单元格";

--- a/macOS/zh-Hans/Scripts.strings
+++ b/macOS/zh-Hans/Scripts.strings
@@ -122,7 +122,7 @@
 "Pai-wM-2Ib.title" = "重命名文件夹";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; Space: Enable/Disable Rules;"; ObjectID = "SQj-Kh-Qo7"; */
-"SQj-Kh-Qo7.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：重复；空格：启用/禁用规则；";
+"SQj-Kh-Qo7.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫： 删除；⌘D：复制；空格：启用/禁用规则；";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Open Custom Addon Folder"; ObjectID = "TNq-P4-Q5X"; */
 "TNq-P4-Q5X.ibShadowedToolTip" = "打开自定义插件文件夹";
@@ -191,7 +191,7 @@
 "eTX-mK-u1J.title" = "插件文档...";
 
 /* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "eTe-5h-VxL"; */
-"eTe-5h-VxL.title" = "重复";
+"eTe-5h-VxL.title" = "复制";
 
 /* Class = "NSMenuItem"; ibShadowedToolTip = "Toggl Enable / Disable selected rules"; ObjectID = "gB7-cb-JeF"; */
 "gB7-cb-JeF.ibShadowedToolTip" = "切换启用/禁用选定规则";

--- a/macOS/zh-Hans/Tools.strings
+++ b/macOS/zh-Hans/Tools.strings
@@ -44,7 +44,7 @@
 "33J-mu-EVh.title" = "编辑...";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "3TH-m3-mox"; */
-"3TH-m3-mox.title" = "新...";
+"3TH-m3-mox.title" = "新建...";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "3p9-uN-0fp"; */
 "3p9-uN-0fp.title" = "文本单元格";
@@ -89,7 +89,7 @@
 "7u5-Hm-wEX.title" = "启用规则";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate;"; ObjectID = "8Mz-VP-qDC"; */
-"8Mz-VP-qDC.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：重复；";
+"8Mz-VP-qDC.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫： 删除；⌘D：复制；";
 
 /* Class = "NSTextFieldCell"; title = "http://api.proxyman.io"; ObjectID = "8Wk-O3-4HB"; */
 "8Wk-O3-4HB.title" = "http://api.proxyman.io";
@@ -188,7 +188,7 @@
 "G4z-qO-dFS.title" = "主机：";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "GD4-VB-I8N"; */
-"GD4-VB-I8N.title" = "新...";
+"GD4-VB-I8N.title" = "新建...";
 
 /* Class = "NSViewController"; title = "Map Remote"; ObjectID = "GcR-SJ-hvI"; */
 "GcR-SJ-hvI.title" = "远程映射";
@@ -260,7 +260,7 @@
 "Mdl-TG-Eas.title" = "主机：";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; Space: Enable/Disable Rules;"; ObjectID = "NiQ-oE-pjP"; */
-"NiQ-oE-pjP.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：重复；空格：启用/禁用规则；";
+"NiQ-oE-pjP.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：复制；空格：启用/禁用规则；";
 
 /* Class = "NSMenuItem"; title = "Edit..."; ObjectID = "Nxm-Kd-hTk"; */
 "Nxm-Kd-hTk.title" = "编辑...";
@@ -404,7 +404,7 @@
 "Y7V-9h-Izy.placeholderString" = "api.proxyman.io";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "YaH-EH-dHs"; */
-"YaH-EH-dHs.title" = "新...";
+"YaH-EH-dHs.title" = "新建...";
 
 /* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "Yuj-DE-Fr5"; */
 "Yuj-DE-Fr5.headerCell.title" = "名称";
@@ -512,7 +512,7 @@
 "eNj-7W-ISv.placeholderString" = "api.proxyman.io/v1/*";
 
 /* Class = "NSTextFieldCell"; title = "⌘N: New; ⌘⏎: Edit; ⌘⌫: Delete; ⌘D: Duplicate; Space: Enable/Disable Rules;"; ObjectID = "eO0-3D-8ut"; */
-"eO0-3D-8ut.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：重复；空格：启用/禁用规则；";
+"eO0-3D-8ut.title" = "⌘N：新建；⌘⏎：编辑；⌘⌫：删除；⌘D：复制；空格：启用/禁用规则；";
 
 /* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "eRn-AX-Ioo"; */
 "eRn-AX-Ioo.title" = "取消";
@@ -566,7 +566,7 @@
 "ivJ-Kh-P4O.title" = "文本单元格";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "j9A-m6-SwX"; */
-"j9A-m6-SwX.title" = "新...";
+"j9A-m6-SwX.title" = "新健...";
 
 /* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "j9L-LL-GiB"; */
 "j9L-LL-GiB.title" = "名称：";
@@ -635,7 +635,7 @@
 "pFe-Rc-k3w.placeholderString" = "/v1/用户";
 
 /* Class = "NSMenuItem"; title = "New..."; ObjectID = "pTQ-wT-bCq"; */
-"pTQ-wT-bCq.title" = "新...";
+"pTQ-wT-bCq.title" = "新建...";
 
 /* Class = "NSTextFieldCell"; title = "Top-Down Matching Rule"; ObjectID = "pud-ei-tlC"; */
 "pud-ei-tlC.title" = "自上而下匹配规则";
@@ -758,7 +758,7 @@
 "yId-We-08h.title" = "有效载荷类型：";
 
 /* Class = "NSMenuItem"; title = "Duplicate"; ObjectID = "yOx-Ov-TOq"; */
-"yOx-Ov-TOq.title" = "重复";
+"yOx-Ov-TOq.title" = "复制";
 
 /* Class = "NSWindow"; title = "Breakpoint rules"; ObjectID = "ybB-CT-jUq"; */
 "ybB-CT-jUq.title" = "断点规则";


### PR DESCRIPTION
Changes:
* Improved/fixed some translations:
  * `New`: `新` -> `新建` (for NSMenuItem and shortcut info field)
  * `Add`: `加` (A plus B) -> `添加` (Add)
  * `Proxyman`:  `代理管理员`(Code Manager) -> `Proxyman`
  * `Format with`: `格式为`(the format is) -> `格式化为`(Format with)
  * `JSON Prettier`
  * Add spaces between Chinese and English
  * And so on.
* Unified translations with previous versions:
  * `Open with` -> `打开方式`
  * `Duplicate` -> `复制`
  *  And so on.